### PR TITLE
Changed the default text from "Web Page" to "Web Resource"

### DIFF
--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -359,7 +359,7 @@ def convert_resource_format(format):
     if format in formats:
         format = RESOURCE_MAPPING[format][1]
     else:
-        format = 'Web Page'
+        format = 'Web Resource'
 
     return format
 


### PR DESCRIPTION
I found that Excel files default to "Web Page" because the file type is not in the RESOURCE_MAPPING section. I did a pull request to update the RESOURCE_MAPPING section of https://github.com/GSA/ckanext-geodatagov/blob/master/ckanext/geodatagov/plugins.py

I think "Web Resource" is more generic and less confusing if the file format is not found in the RESOURCE_MAPPING section.

[RESOURCE_MAPPING.txt](https://github.com/GSA/ckanext-datagovtheme/files/2267718/RESOURCE_MAPPING.txt)
