### PR TITLE
Fix templates

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,4 @@
+graft ckanext/datagovtheme/dynamic_menu
+graft ckanext/datagovtheme/fanstatic_library
+graft ckanext/datagovtheme/public
+graft ckanext/datagovtheme/templates

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
 	url='',
 	license='',
 	packages=find_packages(exclude=['ez_setup', 'examples', 'tests']),
-	namespace_packages=['ckanext', 'ckanext.datagovtheme'],
+	namespace_packages=['ckanext'],
 	include_package_data=True,
 	zip_safe=False,
 	install_requires=[


### PR DESCRIPTION
Resolves https://github.com/GSA/datagov-deploy/issues/524

In debugging this, `pkg_resources` finds the `ckanext.datagovtheme` module, but the module's `__file__` attribute does not exist and then it fails to build the file path to the resource properly. `__file__` would normally point to the `__init__.py` file of the package, but since we're declaring it as a namespace package, the `__init__.py` file doesn't have the same semantics. At least, that's what I understand from [setuptool's docs on namespace packages](https://setuptools.readthedocs.io/en/latest/setuptools.html#namespace-packages).

> When you declare a package to be a namespace package, it means that the package has no meaningful contents in its `__init__.py`, and that it is merely a container for modules and subpackages.

So while `ckanext` is a namespace package, `ckanext.datagovtheme` should not be. This could be a bug in pkg_resources, but I think the intention is that namespace packages shouldn't contain resources.

Additionally, only `.py` files are bundled into the python package, so html files or our xslt templates would not normally be included unless defined in the `MANIFEST.in` template as [data files](https://setuptools.readthedocs.io/en/latest/setuptools.html?highlight=manifest.in#including-data-files). I _think_ this has worked in the past because a) we're installing in develop mode (pip install -e) and b) maybe an older version of setuptools allowed it. I don't know exactly how this was working before.

Finally, I just want to note that `ckanext-spatial`, which is what's triggering the error, has changed [upstream](https://github.com/ckan/ckanext-spatial/blob/541e0cb9b975b711855cf1c0c67892becc344ae1/ckanext/spatial/controllers/api.py#L78) to use `__name__` as it's fallback package name, which wouldn't render to `ckanext.spatial`, but `ckanext.spatial.controllers.api` which is not a namespace package.