### PR TITLE
Changed the default text from "Web Page" to "Web Resource"

### DIFF
--- a/ckanext/datagovtheme/templates/package/resource_read.html
+++ b/ckanext/datagovtheme/templates/package/resource_read.html
@@ -107,7 +107,7 @@
             {% if not res.no_real_name %}
             <tr>
               <th scope="row">{{ _('Name') }}</th>
-              <td>{{ res.name or _('Web Page') }}</td>
+              <td>{{ res.name or _('Web Resource') }}</td>
             </tr>
             {% endif %}
             <tr>


### PR DESCRIPTION
This is another place that the default text needs to be changed to reflect "Web Resource". The "convert_resource_format" function in "https://github.com/GSA/ckanext-datagovtheme/blob/master/ckanext/datagovtheme/helpers.py" was already updated.