### PR TITLE
Change jQuery(window).load(function()... to jQuery(window).on("load", function()...

### DIFF
--- a/ckanext/datagovtheme/fanstatic_library/scripts/datagovtheme.js
+++ b/ckanext/datagovtheme/fanstatic_library/scripts/datagovtheme.js
@@ -135,7 +135,7 @@ $(document).ready(function () {
 
 // fix for dynamic menu to check current domain and assign menu
 
-jQuery(window).load(function(){
+jQuery(window).on("load", function(){
     if (window.location.hostname==='catalog.data.gov'){
         var linkRewriter = function(a, b) {
             $('a[href*="' + a + '"]').each(function() {


### PR DESCRIPTION
1. jQuery.load() with non-string first argument was deprecated long time ago, and removed in jQuery 3.x.
Caused a failure when trying to login.
2. Related to https://github.com/ViderumGlobal/PM-datagov/issues/5