### PR TITLE
Update CSS & HTML to be compatible with Bootstrap CKAN 2.8 upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,4 +23,4 @@ To run the extension tests:
 
 `nosetests --ckan --with-pylons=test.ini ckanext/datagovtheme/tests`
 
-Note: the tests will only run if the environment is installed using the (CKAN Install from Source)[https://docs.ckan.org/en/2.8/maintaining/installing/install-from-source.html#installing-ckan-from-source] installation
+Note: the tests will only run if the environment is installed using the [CKAN Install from Source](https://docs.ckan.org/en/2.8/maintaining/installing/install-from-source.html#installing-ckan-from-source) installation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,14 @@
 # ckanext-datagovtheme
 This repository is front end code sepration for catalog.data.gov. This contains all the template files, Javascripts and stylesheets.
-This extension is dependent on the [ckanext-geodatagov extension](https://github.com/GSA/ckanext-geodatagov) for geospatial functionality.
-The ckanext-geodatagov extension is dependent on the [ckanext-spatial extension](https://github.com/ckan/ckanext-spatial).
+
+The [ckanext-geodatagov](https://github.com/GSA/ckanext-geodatagov) and [ckanext-spatial](https://github.com/ckan/ckanext-spatial) extensions must be [installed and enabled](https://docs.ckan.org/en/2.8/extensions/tutorial.html#installing-the-extension) as plugins before this extension can be installed and enabled.
+
+This extension as well as the dependent extensions above must be installed properly with CKAN before running the tests for this extension.
+
+The tests for this extension are located in the [test directory](/ckanext/datagovtheme/tests/test_datagovetheme.py).
+
+They follow the guidelines for [testing CKAN extensions](https://docs.ckan.org/en/2.8/extensions/testing-extensions.html#testing-extensions).
+
+To run the extension tests, cd into the ckanext-datagovtheme directory and run this command:
+
+`nosetests --ckan --with-pylons=test.ini ckanext/datagovthem/tests`

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # ckanext-datagovtheme
 This repository is front end code sepration for catalog.data.gov. This contains all the template files, Javascripts and stylesheets.
-This is dependent on ckanext-geodatagov for geospatial functionality.
+This extension is dependent on the [ckanext-geodatagov extension](https://github.com/GSA/ckanext-geodatagov) for geospatial functionality.
+The ckanext-geodatagov extension is dependent on the [ckanext-spatial extension](https://github.com/ckan/ckanext-spatial).

--- a/README.md
+++ b/README.md
@@ -9,6 +9,18 @@ The tests for this extension are located in the [test directory](/ckanext/datago
 
 They follow the guidelines for [testing CKAN extensions](https://docs.ckan.org/en/2.8/extensions/testing-extensions.html#testing-extensions).
 
-To run the extension tests, cd into the ckanext-datagovtheme directory and run this command:
+To run the extension tests:
+
+1. Make sure your virtual environment is activated
+
+`. /usr/lib/ckan/default/bin/activate`
+
+2. cd into the ckanext-datagovtheme directory
+
+`cd /usr/lib/ckan/default/src/ckanext-datagovtheme`
+
+3. Use the nosetests command:
 
 `nosetests --ckan --with-pylons=test.ini ckanext/datagovtheme/tests`
+
+Note: the tests will only run if the environment is installed using the (CKAN Install from Source)[https://docs.ckan.org/en/2.8/maintaining/installing/install-from-source.html#installing-ckan-from-source] installation

--- a/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
@@ -745,7 +745,7 @@ a {
     position: relative;
     bottom: 0;
     float: right;
-    width: 23%;
+    width: 150px;
     margin-top: -5px;
     margin-left: 10px;
 }
@@ -1730,7 +1730,7 @@ aside.secondary{
 }
 #menu-primary-navigation.navbar-right{margin-right:3px;}
 .search-form .input-group {
-    width: 458px;
+    display: inline;
 }
 form.search-form{padding-right:0px;border-bottom: 0px;padding-bottom:0px;}
 .module-content.page-header {

--- a/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
@@ -1730,6 +1730,9 @@ aside.secondary{
 }
 #menu-primary-navigation.navbar-right{margin-right:3px;}
 .search-form .input-group {
+    width: 458px;
+}
+.module-content .search-form .input-group {
     display: inline;
 }
 form.search-form{padding-right:0px;border-bottom: 0px;padding-bottom:0px;}

--- a/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
@@ -107,8 +107,6 @@ a {
 }
 .btn-primary {
     color: white !important;
-    /*background: #284a7a !important;*/
-
 }
 .btn-primary:hover {
     background: #1b3354 !important;
@@ -137,20 +135,10 @@ a {
 .masthead .container {
     width: 970px;
     margin-top: 8px;
-    /* background: #ffffff url("../images/header-line.png?1") 100% 100% no-repeat;
-     -webkit-border-radius: 3px 3px 0 0;
-     -moz-border-radius: 3px 3px 0 0;
-     -o-border-radius: 3px 3px 0 0;
-     border-radius: 3px 3px 0 0;*/
 }
 .masthead .container .top {
     *zoom: 1;
     position: relative;
-    /*  background: url("http://www.data.gov/sites/all/themes/datagov/images/header-start-bg.jpg");
-      -webkit-border-radius: 4px 4px 0 0;
-      -moz-border-radius: 4px 4px 0 0;
-      -o-border-radius: 4px 4px 0 0;
-      border-radius: 4px 4px 0 0;*/
 }
 .masthead .container .top:before,
 .masthead .container .top:after {
@@ -297,7 +285,6 @@ a {
 .masthead .container .top-nav {
     clear: both;
     background-color: transparent;
-    /*padding: 0 10px;*/
     margin-bottom: 0;
 }
 .masthead .container .top-nav nav ul {
@@ -317,8 +304,6 @@ a {
     text-decoration: none;
 }
 .masthead .container .top-nav .primary {
-    /* background: #284a7a url("../images/header-nav-bg.png");
-   */
     float:right;
     width:650px;
 }
@@ -331,10 +316,6 @@ a {
     line-height: 33px;
     color:#333;
 }
-.masthead .container .top-nav .primary ul li a:hover {
-    /*background-color: #5881b0;
-    border-left-color: #5881b0;
-  */}
 .masthead .container .top-nav .primary ul li a.root {
     border-left: 1px solid #294B78;
     border-right: 1px solid #0B3064;
@@ -362,17 +343,6 @@ a {
 .masthead .container .top-nav .primary ul li.sub-dropdown:hover .dropdown {
     display: block;
 }
-.masthead .container .top-nav .primary .dropdown {
-    /*  display: none;
-      position: absolute;
-      z-index: 100;
-      margin-left: 1px;
-      background-color: #366c9f;
-      -webkit-box-shadow: 0 4px 4px rgba(0, 0, 0, 0.3);
-      -moz-box-shadow: 0 4px 4px rgba(0, 0, 0, 0.3);
-      -o-box-shadow: 0 4px 4px rgba(0, 0, 0, 0.3);
-      box-shadow: 0 4px 4px rgba(0, 0, 0, 0.3);
-    */}
 .masthead .container .top-nav .primary .dropdown li {
     float: none;
 }
@@ -782,9 +752,6 @@ a {
 .control-order-by select {
     margin-bottom: 0;
 }
-/* .secondary .module {
-    margin: 10px 0;
-} */
 .secondary .module .module-content.empty {
     font-size: 13px;
 }
@@ -957,7 +924,6 @@ input.search-new{
 .module-heading span {
     display:block;
 }
-/* body{font-size:87.5%;} */
 #dataset-map-attribution div a{text-decoration:underline;}
 .empty{color:#595959;}
 #exitURL{position:absolute;right:15px;width:150px;color:#000;top:35px;z-index:999;}
@@ -971,7 +937,6 @@ header .header_new.banner_new.page-heading_new  {
 }
 .page-header_new  {
     border-bottom: medium none;
-    /* margin: 44px 0 22px;*/
     padding-bottom: 0;
 }
 .page-header_new  h1 {
@@ -997,9 +962,6 @@ body .searchbox-row.skip-navigation {
 #menu-primary-navigation {
     float: right;
 }
-/* .navbar .search-form {
-    padding-top: 8px;
-} */
 input.form-control {
     display:block;
     width:78%;
@@ -1180,7 +1142,6 @@ footer.site-footer {
     width: 16.6667%;
 }
 .col-md-offset-1 {
-    /*margin-left: 8.33333%;*/
 }
 .col-md-3 {
     width: 25%;
@@ -1302,7 +1263,6 @@ body {
     clear:both;
     display:inline-block;
     text-align:center;
-    /* overflow:hidden; */
     font-size:50px;
 }
 ul.topics li a i:hover {
@@ -1494,10 +1454,7 @@ aside.secondary{
     margin-left: 0;
     border-width: 0;
 }
-/* .wrapper {
-    background: url("../../../../base/images/nav.png") repeat-y scroll 16px 0 #ffffff;
 
-} */
 #content .toolbar .add_action {
     position: static !important;
     float: right;
@@ -1536,7 +1493,6 @@ aside.secondary{
     display: block;
 }
 #sort_option {
-    /*display: none;*/
     clear:both;
     margin-bottom: 10px;
     font-size: 14px;
@@ -1592,20 +1548,16 @@ aside.secondary{
     text-decoration: none;
     background:none;
 }
-#menu-community{/*margin-top:5px;*/
+#menu-community{
     margin-left: 15px;
 }
 .results strong, .is-search-title{display:inline-block;}
 .active_jquery_menu.active {
     border-bottom: 5px solid #ccc;
 }
-/* .page-header_new .toolbar{background: none !important;} */
 .ie10 .page-header_new .toolbar .breadcrumb a {
     font-weight:lighter;
 }
-.module .module-content .dataset-search {
-    /* margin-top: -20px;
- */}
 
 .topic-health a i:before{
     content: "\e00d";
@@ -1777,7 +1729,6 @@ aside.secondary{
     margin-left: 2px;
 }
 #menu-primary-navigation.navbar-right{margin-right:3px;}
-/* .masthead input#search-header.form-control{width:84.5%;margin-left:1px;} */
 .search-form .input-group {
     width: 458px;
 }
@@ -1786,15 +1737,9 @@ form.search-form{padding-right:0px;border-bottom: 0px;padding-bottom:0px;}
     padding-top: 20px;
 }
 
-/* [role="main"] .primary {
-    width: 732px;
-} */
 .controller-organization.action-read .primary,.controller-package.action-read .primary {
     width: 714px;
 }
-/* .controller-organization.action-index .primary {
-    width: 729px;
-} */
 
 .search-form.no-bottom-border {
     display: flex;
@@ -2088,9 +2033,6 @@ color:#2a6496;
 .navbar-toggle .icon-bar + .icon-bar {
     margin-top: 4px;
 }
-/* .span9 div.module-content {
-padding-left:25px;
-} */
 .site-footer .nav > li > a:hover {
     color: #428bca;
 }
@@ -2145,9 +2087,6 @@ margin-top: 0px;
     color: #fff;
 }
 
-/* aside.secondary{
-    width:236px;
-} */
 /* media Queries */
 /* chrome specific queries*/
 @media screen and (-webkit-min-device-pixel-ratio:0) {
@@ -2228,9 +2167,7 @@ margin-top: 0px;
     .navbar-right {
         float:none;
     }
-    /* .search-form{
 
-    } */
     #menu-primary-navigation {
         float: none;
     }

--- a/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
@@ -36,10 +36,20 @@ body,
     border-radius: 0 0 3px 3px;
     border-top:0px;
 }
+.row.wrapper {
+    margin-left: auto;
+    margin-right: auto;
+    position: sticky;
+}
 .masthead,
 .site-footer {
     background-color: transparent;
 }
+
+.masthead {
+    padding-bottom: 0;
+}
+
 [role=main] {
     padding-top: 0;
 }
@@ -97,7 +107,7 @@ a {
 }
 .btn-primary {
     color: white !important;
-    /*background: #284a7a !important;*/:w
+    /*background: #284a7a !important;*/
 
 }
 .btn-primary:hover {
@@ -216,7 +226,7 @@ a {
     -moz-border-radius: 2px;
     -o-border-radius: 2px;
     border-radius: 2px;
-    vertical-align: -3px;
+    /* vertical-align: -3px; */
 }
 .masthead .container .account-wrapper ul {
     *zoom: 1;
@@ -233,6 +243,8 @@ a {
 .masthead .container .account-wrapper ul li {
     float: left;
     border-right: 1px solid #c0cfe1;
+    font-size: 14px;
+    color: transparent;
 }
 .masthead .container .account-wrapper ul li a {
     display: block;
@@ -678,6 +690,7 @@ a {
     padding-right: 80px;
 }
 .dataset-item.has-organization .notes {
+    font-size: 14px;
     padding-right: 50px;
 }
 .results,
@@ -762,15 +775,16 @@ a {
     position: relative;
     bottom: 0;
     float: right;
-    margin-top: -7px;
+    width: 23%;
+    margin-top: -5px;
     margin-left: 10px;
 }
 .control-order-by select {
     margin-bottom: 0;
 }
-.secondary .module {
+/* .secondary .module {
     margin: 10px 0;
-}
+} */
 .secondary .module .module-content.empty {
     font-size: 13px;
 }
@@ -799,8 +813,8 @@ a {
     color: #000;
     text-decoration: underline;
 }
-.secondary .module .module-heading .icon-filter,
-.secondary .module .module-heading .icon-globe {
+.secondary .module .module-heading .fa-filter,
+.secondary .module .module-heading .fa-globe {
     display: none;
 }
 #debug-toggle,
@@ -943,7 +957,7 @@ input.search-new{
 .module-heading span {
     display:block;
 }
-body{font-size:87.5%;}
+/* body{font-size:87.5%;} */
 #dataset-map-attribution div a{text-decoration:underline;}
 .empty{color:#595959;}
 #exitURL{position:absolute;right:15px;width:150px;color:#000;top:35px;z-index:999;}
@@ -983,15 +997,15 @@ body .searchbox-row.skip-navigation {
 #menu-primary-navigation {
     float: right;
 }
-.navbar .search-form {
+/* .navbar .search-form {
     padding-top: 8px;
-}
+} */
 input.form-control {
     display:block;
     width:78%;
     display:table-cell;
     float: left;
-    /*height:36px;*/
+    height:36px;
     padding:6px 12px 8px;
     font-size:16px;
     line-height:1.428571429;
@@ -1288,7 +1302,7 @@ body {
     clear:both;
     display:inline-block;
     text-align:center;
-    overflow:hidden;
+    /* overflow:hidden; */
     font-size:50px;
 }
 ul.topics li a i:hover {
@@ -1335,6 +1349,7 @@ ul.topics li a i:hover {
 .ie10 .yamm-fw .dropdown-menu{min-width:970px;padding:10px 0;}
 #menu-primary-navigation ul.topics{
     text-align: center;
+    background: white;
 }
 .masthead .container .top-nav .primary ul li a:hover .caret {
     border-bottom-color: #777777;
@@ -1479,10 +1494,10 @@ aside.secondary{
     margin-left: 0;
     border-width: 0;
 }
-.wrapper {
+/* .wrapper {
     background: url("../../../../base/images/nav.png") repeat-y scroll 16px 0 #ffffff;
 
-}
+} */
 #content .toolbar .add_action {
     position: static !important;
     float: right;
@@ -1501,10 +1516,10 @@ aside.secondary{
     position: relative;
 }
 .page-header_new .toolbar {
-    background: none repeat scroll 0 0 rgba(0, 0, 0, 0);
+    background: none !important;
+    display: flex;
+    align-items: center;
     border: 0 none;
-    float: left;
-    /*width: 320px;*/
     padding-top: 13px;
 }
 .control-group.search-giant {
@@ -1524,6 +1539,7 @@ aside.secondary{
     /*display: none;*/
     clear:both;
     margin-bottom: 10px;
+    font-size: 14px;
 }
 .page-header_new .toolbar .add_action{position:static;float:right;}
 .page-header_new .toolbar .breadcrumb{float:right;margin-right:15px;margin-top:5px;}
@@ -1543,12 +1559,22 @@ aside.secondary{
     float:none !important;
 
 }
-.question .icon-question-sign{font-size:32px;}
+.fa-question-circle {
+    font-size: 32px;
+}
+
 .main-heading {
     float: left;
     width: 590px;
     padding:10px 0;
 }
+
+.fa-home {
+    font-size: 24px;
+    width: 24px;
+    vertical-align: -1px;
+}
+
 .page-header_new .toolbar .breadcrumb a {
     color: #fff;
     font-weight: normal;
@@ -1573,7 +1599,7 @@ aside.secondary{
 .active_jquery_menu.active {
     border-bottom: 5px solid #ccc;
 }
-.page-header_new .toolbar{background: none !important;}
+/* .page-header_new .toolbar{background: none !important;} */
 .ie10 .page-header_new .toolbar .breadcrumb a {
     font-weight:lighter;
 }
@@ -1751,7 +1777,7 @@ aside.secondary{
     margin-left: 2px;
 }
 #menu-primary-navigation.navbar-right{margin-right:3px;}
-.masthead input#search-header.form-control{width:84.5%;margin-left:1px;}
+/* .masthead input#search-header.form-control{width:84.5%;margin-left:1px;} */
 .search-form .input-group {
     width: 458px;
 }
@@ -1760,15 +1786,45 @@ form.search-form{padding-right:0px;border-bottom: 0px;padding-bottom:0px;}
     padding-top: 20px;
 }
 
-[role="main"] .primary {
+/* [role="main"] .primary {
     width: 732px;
-}
+} */
 .controller-organization.action-read .primary,.controller-package.action-read .primary {
     width: 714px;
 }
-.controller-organization.action-index .primary {
+/* .controller-organization.action-index .primary {
     width: 729px;
+} */
+
+.search-form.no-bottom-border {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
 }
+
+#field-giant-search {
+    width: 458px;
+    height: 46px;
+}
+
+.input-group.search-input-group .input-group-btn {
+    display: none;
+}
+
+article .module-content {
+    padding-left: 10px;
+    padding-right: 10px;
+}
+
+.media-grid {
+    margin-left: -20px;
+    margin-right: -20px;
+}
+
+.search-form h2 {
+    margin-top: -10px;
+}
+
 .primary .primary {
 
     width: 479px;
@@ -1804,7 +1860,7 @@ p.module-content{padding-left: 18px !important;}
     margin: 10px auto 0;
 }
 
-.no-resource .icon-exclamation-sign, .no-resource .icon-lock{
+.no-resource .icon-exclamation-sign, .no-resource .fa-lock{
     color: #b85123;
     font-size: 30px;
     margin-right: 15px;
@@ -1852,12 +1908,12 @@ p.module-content{padding-left: 18px !important;}
 }
 #access-use span{display:block}
 #access-use i{ margin-right:10px;text-align: left;}
-#access-use .icon-lock,
+#access-use .fa-lock,
 #access-use .icon-key {
     font-size: 14px;
     margin-left: 0;
 }
-#access-use .icon-globe {
+#access-use .fa-globe {
     font-size: 14px;
     margin-left: 0;
 }
@@ -1866,11 +1922,11 @@ p.module-content{padding-left: 18px !important;}
 #access-use .access-restricted strong {
     color: #b85123;
 }
-#access-use .icon-globe,
+#access-use .fa-globe,
 #access-use .access-public strong {
     color: #4679b2;
 }
-#access-use .icon-lock,
+#access-use .fa-lock,
 #access-use .access-non-public strong {
     color: #b85123;
 }
@@ -1886,7 +1942,7 @@ p.module-content{padding-left: 18px !important;}
     width: 660px;
     color:#444;
 }
-.non-federal .icon-info-sign
+.non-federal .fa-info-sign
 {
     color: #444;
     float: left;
@@ -1980,6 +2036,19 @@ margin-top : 2.5em;
 .col-md-5 {
     width: 43%;
 }
+.dataset-list.unstyled {
+    padding-left: 0;
+    list-style: none;
+}
+
+.dataset-resources  {
+    padding: 0;
+}
+
+.dataset-resources li a {
+    font-size: 12px;
+}
+
 .module.prose .module-content .dataset-list.unstyled .dataset-item .dataset-content{padding-bottom:0px;}
 .module.prose .module-content .dataset-list.unstyled .dataset-item .dataset-resources.unstyled{margin-bottom:30px;}
 .site-footer .nav > li > a {
@@ -1995,16 +2064,20 @@ color:#2a6496;
 .navbar .nav > li > .dropdown-menu::after{
     display: none;
 }
-.masthead .btn-navbar {
+
+.masthead .navbar-collapse {
+    padding: 0;
+}
+
+.masthead .navbar-toggle {
     border:1px solid #ddd;
     background: none;
     padding: 9px 10px;
 }
-.masthead .btn-navbar:hover {
-
+.masthead .navbar-toggle:hover {
     background: #ddd;
 }
-.navbar .btn-navbar .icon-bar {
+.navbar .navbar-toggle .icon-bar {
     background-color: #ccc;
     border-radius: 1px;
     display: block;
@@ -2012,12 +2085,12 @@ color:#2a6496;
     width: 22px;
     box-shadow: none;
 }
-.btn-navbar .icon-bar + .icon-bar {
+.navbar-toggle .icon-bar + .icon-bar {
     margin-top: 4px;
 }
-.span9 div.module-content {
+/* .span9 div.module-content {
 padding-left:25px;
-}
+} */
 .site-footer .nav > li > a:hover {
     color: #428bca;
 }
@@ -2046,7 +2119,7 @@ padding-left:25px;
 .navbar .btn, .navbar .btn-group {
 margin-top: 0px;
 }
-.btn.btn-navbar{
+.btn.navbar-toggle{
     margin-top:15px;
 }
 .module-heading .action {
@@ -2062,7 +2135,7 @@ margin-top: 0px;
 }
 .page_primary_action {
     position: absolute;
-    margin-top: -58px;
+    margin-top: -71px;
     right: 10px;
 }
 .toolbar .breadcrumb a, .toolbar .breadcrumb {
@@ -2071,9 +2144,10 @@ margin-top: 0px;
 .page-header_new .toolbar .breadcrumb a, .page-header_new .toolbar .breadcrumb {
     color: #fff;
 }
-aside.secondary{
+
+/* aside.secondary{
     width:236px;
-}
+} */
 /* media Queries */
 /* chrome specific queries*/
 @media screen and (-webkit-min-device-pixel-ratio:0) {
@@ -2154,9 +2228,9 @@ aside.secondary{
     .navbar-right {
         float:none;
     }
-    .search-form{
+    /* .search-form{
 
-    }
+    } */
     #menu-primary-navigation {
         float: none;
     }
@@ -2247,7 +2321,7 @@ aside.secondary{
     .controller-organization .wrapper{
         margin:0px;
     }
-    .input-append, .input-prepend {
+    .input-group {
         white-space: normal;
     }
     .control-custom input {
@@ -2258,4 +2332,10 @@ aside.secondary{
         border-radius: 0;
         width: 100%;
     }
+}
+
+.faded.disclaimer {
+    margin-bottom:10px;
+    visibility: hidden;
+    height:0px;
 }

--- a/ckanext/datagovtheme/fanstatic_library/styles/datasets.less
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datasets.less
@@ -158,8 +158,8 @@
         text-decoration: underline;
       }
     }
-    .icon-filter,
-    .icon-globe {
+    .fa-filter,
+    .fa-globe {
       display: none;
     }
   }

--- a/ckanext/datagovtheme/templates/footer.html
+++ b/ckanext/datagovtheme/templates/footer.html
@@ -4,13 +4,13 @@
 
 
         <div class="fluid-row">
-            <div class="span6 clearfix">
+            <div class="col-md-6 clearfix">
                 <div class="footer-logo"> <a href="http://www.data.gov/" class="logo-brand">Data.Gov 2.0</a> </div>
                 <ul class="nav" id="menu-footer2">
                     {% snippet "snippets/footer2_menu.html" %}
                 </ul>
             </div>
-            <nav role="navigation" class="span3">
+            <nav role="navigation" class="col-md-3">
                 <ul class="nav" id="menu-footer">
                     {% snippet "snippets/footer_menu.html" %}
                     {% if c.userobj%}
@@ -20,7 +20,7 @@
                     {% endif  %}
                 </ul>
             </nav>
-            <div class="span3 social-nav">
+            <div class="col-md-3 social-nav">
                 <nav role="navigation">
                     <ul class="nav" id="menu-social_navigation">
                         <li><a href="https://twitter.com/usdatagov"><i class="fa fa-twitter"></i><span>Twitter</span></a></li>

--- a/ckanext/datagovtheme/templates/group/index.html
+++ b/ckanext/datagovtheme/templates/group/index.html
@@ -3,7 +3,7 @@
 {% block secondary_content %}
   <div class="module module-narrow module-shallow">
     <h2 class="module-heading">
-      <i class="icon-info-sign"></i>
+      <i class="fa fa-info-circle"></i>
       {{ _('What are groups?') }}
     </h2>
     <div class="module-content">

--- a/ckanext/datagovtheme/templates/header.html
+++ b/ckanext/datagovtheme/templates/header.html
@@ -114,7 +114,7 @@
                         {% endblock %}
                     <div class="add_action">
                         <a href="{{ h.url_for('organizations_index') }}" class="btn btn_new">{{ _('Organizations') }}</a>
-                        <a href="http://www.data.gov/catalog-help/" class="btn btn-primary question"><i class="fa fa-question-circle"></i></a>
+                        <a href="https://www.data.gov/catalog-help/" class="btn btn-primary question"><i class="fa fa-question-circle"></i></a>
                     </div>
                 </div>
             </div>

--- a/ckanext/datagovtheme/templates/header.html
+++ b/ckanext/datagovtheme/templates/header.html
@@ -13,19 +13,17 @@
                 <a href="#">Jump to Content</a>
             </div>
             <div>
-                <form action="/dataset" class="search-form form-inline navbar-right navbar-nav  col-sm-6 col-md-6 col-lg-6" method="get" role="search">
+                <form action="/dataset" class="search-form form-inline navbar-right navbar-nav" method="get" role="search">
                     <div class="input-group">
                         <label class="hide" for="search-header">Search for:</label>
-
                         <input type="search" placeholder="Search Data.Gov" class="search-field form-control" name="q" value="Search Data.Gov" id="search-header" onblur="if(value=='') value = 'Search Data.Gov'" onfocus="if(value=='Search Data.Gov') value = ''">      <span class="input-group-btn">
-      <button class="search-submit btn_new btn-default" type="submit">
-          <i class="fa fa-search"></i>
-          <span class="sr-only">Search</span>
-      </button>
-    </span>
+                            <button class="search-submit btn_new btn-default" type="submit">
+                                <i class="fa fa-search"></i>
+                                <span class="sr-only">Search</span>
+                            </button>
+                        </span>
                     </div>
                 </form>
-
             </div>
         </div>
         <hgroup class="top">
@@ -37,32 +35,35 @@
                     <ul class="unstyled">
                         {% if c.userobj.sysadmin %}
                         <li>
-                            <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
-                                <i class="icon-legal"></i>
+                            <a href="{{ h.url_for(controller='admin', action='index') }}"
+                                title="{{ _('Sysadmin settings') }}">
+                                <i class="fa fa-gavel" aria-hidden="true"></i>
                             </a>
                         </li>
                         {% endif %}
                         <li>
-                            <a href="{{ h.url_for(controller='user', action='read', id=c.userobj.name) }}" class="image" title="{{ _('View profile') }}">
-                                {{ h.gravatar((c.userobj.email_hash if c and c.userobj else ''), size=16) }}
-                                {{ c.userobj.display_name }}
+                            <a href="{{ h.url_for('user.read', id=c.userobj.name) }}" class="image"
+                                title="{{ _('View profile') }}">
+                                {{ h.gravatar((c.userobj.email_hash if c and c.userobj else ''), size=22) }}
+                                <span class="username">{{ c.userobj.display_name }}</span>
                             </a>
                         </li>
-                        <li class="notifications {% if c.new_activities > 0 %}notifications-important{% endif %}">
-                            {% set new_activities = h.new_activities() %}
-                            <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
-                                <i class="icon-dashboard"></i>
+                        {% set new_activities = h.new_activities() %}
+                        <li class="notifications {% if new_activities > 0 %}notifications-important{% endif %}">
+                            {% set notifications_tooltip = ngettext('Dashboard (%(num)d new item)', 'Dashboard (%(num)d new items)', new_activities) %}
+                            <a href="{{ h.url_for('dashboard.index') }}" title="{{ notifications_tooltip }}">
+                                <i class="fa fa-tachometer" aria-hidden="true"></i>
                                 <span>{{ new_activities }}</span>
                             </a>
                         </li>
                         <li>
                             <a href="{{ h.saml2_user_edit_url() }}" title="{{ _('Edit settings') }}">
-                                <i class="icon-cog"></i>
+                                <i class="fa fa-cog" aria-hidden="true"></i>
                             </a>
                         </li>
                         <li>
                             <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
-                                <i class="icon-signout"></i>
+                                <i class="fa fa-sign-out" aria-hidden="true"></i>
                             </a>
                         </li>
                     </ul>
@@ -105,17 +106,16 @@
                 </div>
 
                 <div class="toolbar">
+                        {% block breadcrumb %}
+                        <ol class="breadcrumb">
+                            <li class="home"><a href="{{ h.url(controller='package', action='search') }}"><i class="fa fa-home"></i><span> {{ _('Home') }}</span></a></li>
+                            <li class="active">{{ h.nav_link(_('Datasets'), controller='package', action='search', highlight_actions = 'new index') }}</li>
+                        </ol>
+                        {% endblock %}
                     <div class="add_action">
                         <a href="{{ h.url_for('organizations_index') }}" class="btn btn_new">{{ _('Organizations') }}</a>
-                        <a href="http://www.data.gov/catalog-help/" class="btn btn-primary question"><i class="icon-question-sign"></i></a>
+                        <a href="http://www.data.gov/catalog-help/" class="btn btn-primary question"><i class="fa fa-question-circle"></i></a>
                     </div>
-                    {% block breadcrumb %}
-                    <ol class="breadcrumb">
-                        <li class="home"><a href="{{ h.url(controller='package', action='search') }}"><i class="icon-home"></i><span> {{ _('Home') }}</span></a></li>
-                        <li class="active">{{ h.nav_link(_('Datasets'), controller='package', action='search', highlight_actions = 'new index') }}</li>
-                    </ol>
-                    {% endblock %}
-
                 </div>
             </div>
         </div>

--- a/ckanext/datagovtheme/templates/home/index.html
+++ b/ckanext/datagovtheme/templates/home/index.html
@@ -12,7 +12,7 @@
           <p>Geospatial data from across the government is collected here and made accessible for easier searching. Just enter your search terms in the box to the right to get started. You can search by publisher by clicking on Organizations at the top, or by all categories (organizations, topics, and formats) by clicking on Datasets at the top.</p>
         </div>
         <form class="search-box clearfix" method="get" action="{% url_for controller='package', action='search' %}">
-          <span class="control-group search-giant">
+          <span class="form-group search-giant">
             <input type="text" class="search" name="q" value="{{ c.q }}" autocomplete="off" placeholder="{{ _('Search datasets...') }}" />
             <button type="submit" value="{{ _('Search') }}">Submit</button>
           </span>

--- a/ckanext/datagovtheme/templates/organization/index.html
+++ b/ckanext/datagovtheme/templates/organization/index.html
@@ -3,7 +3,7 @@
 {% block secondary_content %}
   <div class="module module-narrow module-shallow">
     <h2 class="module-heading">
-      <i class="icon-info-sign"></i>
+      <i class="fa fa-info-circle"></i>
       {{ _('What are organizations?') }}
     </h2>
     <div class="module-content">

--- a/ckanext/datagovtheme/templates/organization/read.html
+++ b/ckanext/datagovtheme/templates/organization/read.html
@@ -41,6 +41,6 @@
     {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
     {% endfor %}
     </div>
-    <a class="close no-text hide-filters"><i class="icon-remove-sign"></i><span class="text">close</span></a>
+    <a class="close no-text hide-filters"><i class="fa fa-times"></i><span class="text">close</span></a>
 </div>
 {% endblock %}

--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -55,15 +55,16 @@
 
 
 {% block package_resources %}
+{% set accessLevel = "https://resources.data.gov/schemas/dcat-us/v1.1/#accessLevel" %}
 <section class="information module-content" id="access-use">
   <h3>Access &amp; Use Information</h3>
   <div class="access-use-main">
   {% if h.get_pkg_dict_extra(pkg, 'accessLevel') == 'non-public' %}
-  <span class="access-non-public"><i class="fa fa-lock"></i><strong><a href="https://project-open-data.cio.gov/v1.1/schema/#accessLevel">Non-public:</a></strong> This dataset is not for public access or use. Specific details are provided below.</span>
+  <span class="access-non-public"><i class="fa fa-lock"></i><strong><a href={{accessLevel}}>Non-public:</a></strong> This dataset is not for public access or use. Specific details are provided below.</span>
   {% elif h.get_pkg_dict_extra(pkg, 'accessLevel') == 'public' %}
-  <span class="access-public"><i class="fa fa-globe"></i><strong><a href="https://project-open-data.cio.gov/v1.1/schema/#accessLevel">Public:</a></strong> This dataset is intended for public access and use.</span>
+  <span class="access-public"><i class="fa fa-globe"></i><strong><a href="{{accessLevel}}">Public:</a></strong> This dataset is intended for public access and use.</span>
   {% elif h.get_pkg_dict_extra(pkg, 'accessLevel') == 'restricted public' %}
-  <span class="access-restricted"><i class="icon-key"></i><strong><a href="https://project-open-data.cio.gov/v1.1/schema/#accessLevel">Restricted:</a></strong> This dataset can only be accessed or used under certain conditions. </span>
+  <span class="access-restricted"><i class="icon-key"></i><strong><a href="{{accessLevel}}">Restricted:</a></strong> This dataset can only be accessed or used under certain conditions. </span>
   {% endif %}
   {% if pkg_dict.organization.organization_type != 'Federal Government' %}
     <span><i class="fa fa-info-circle"></i><strong>Non-Federal:</strong> This dataset is covered by different Terms of Use than Data.gov.

--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -10,7 +10,7 @@
 <section class="module-content" style="padding-top:0px;">
     {% if pkg.private %}
       <span class="dataset-private label label-inverse pull-right">
-        <i class="icon-lock"></i>
+        <i class="fa fa-lock"></i>
         {{ _('Private') }}
       </span>
     {% endif %}
@@ -59,14 +59,14 @@
   <h3>Access &amp; Use Information</h3>
   <div class="access-use-main">
   {% if h.get_pkg_dict_extra(pkg, 'accessLevel') == 'non-public' %}
-  <span class="access-non-public"><i class="icon-lock"></i><strong><a href="https://project-open-data.cio.gov/v1.1/schema/#accessLevel">Non-public:</a></strong> This dataset is not for public access or use. Specific details are provided below.</span>
+  <span class="access-non-public"><i class="fa fa-lock"></i><strong><a href="https://project-open-data.cio.gov/v1.1/schema/#accessLevel">Non-public:</a></strong> This dataset is not for public access or use. Specific details are provided below.</span>
   {% elif h.get_pkg_dict_extra(pkg, 'accessLevel') == 'public' %}
-  <span class="access-public"><i class="icon-globe"></i><strong><a href="https://project-open-data.cio.gov/v1.1/schema/#accessLevel">Public:</a></strong> This dataset is intended for public access and use.</span>
+  <span class="access-public"><i class="fa fa-globe"></i><strong><a href="https://project-open-data.cio.gov/v1.1/schema/#accessLevel">Public:</a></strong> This dataset is intended for public access and use.</span>
   {% elif h.get_pkg_dict_extra(pkg, 'accessLevel') == 'restricted public' %}
   <span class="access-restricted"><i class="icon-key"></i><strong><a href="https://project-open-data.cio.gov/v1.1/schema/#accessLevel">Restricted:</a></strong> This dataset can only be accessed or used under certain conditions. </span>
   {% endif %}
   {% if pkg_dict.organization.organization_type != 'Federal Government' %}
-    <span><i class="icon-info-sign"></i><strong>Non-Federal:</strong> This dataset is covered by different Terms of Use than Data.gov.
+    <span><i class="fa fa-info-circle"></i><strong>Non-Federal:</strong> This dataset is covered by different Terms of Use than Data.gov.
     {% if pkg_dict.organization.terms_of_use %}
         <a href="{{ pkg_dict.organization.terms_of_use }}" style="text-decoration:underline;">See Terms</a>
      {% endif %}
@@ -271,7 +271,7 @@
             </li>
           {% endif %}
         </ul>
-        <p class="muted">{{ h.get_harvest_source_link(pkg) }}</p>
+        <p class="text-muted">{{ h.get_harvest_source_link(pkg) }}</p>
       </section>
     {% endif %}
   {% endif %}

--- a/ckanext/datagovtheme/templates/package/read_base.html
+++ b/ckanext/datagovtheme/templates/package/read_base.html
@@ -23,10 +23,10 @@
 </div>
 {% endblock %}
 {% if h.get_pkg_dict_extra(pkg, 'accessLevel') == 'non-public' %}
-<div class="no-resource disclaimer"><i class="icon-lock"></i><span>This metadata record is available for the public, but the data itself is not public for privacy or security reasons. <a href="#access-use" style="text-decoration:underline;">See details</a></span></div>
+<div class="no-resource disclaimer"><i class="fa fa-lock"></i><span>This metadata record is available for the public, but the data itself is not public for privacy or security reasons. <a href="#access-use" style="text-decoration:underline;">See details</a></span></div>
 {% endif %}
 {% if c.pkg_dict.organization.organization_type != 'Federal Government' %}
-<div class="alert-info non-federal"><i class="icon-info-sign"></i><span>This is a Non-Federal dataset covered by different Terms of Use than Data.gov.
+<div class="alert-info non-federal"><i class="fa fa-info-circle"></i><span>This is a Non-Federal dataset covered by different Terms of Use than Data.gov.
      {% if c.pkg_dict.organization.terms_of_use %}
         <a href="{{ c.pkg_dict.organization.terms_of_use }}" style="text-decoration:underline;">See Terms</a>
      {% endif %}
@@ -71,7 +71,7 @@
 {% block package_groups %}
 {% if pkg.groups %}
 <div class="module module-narrow">
-    <h2 class="module-heading"><i class="icon-folder-open"></i> {{ _('Topics') }}</h2>
+    <h2 class="module-heading"><i class="fa fa-folder-open"></i>{{ _('Topics') }}</h2>
     <ul class="nav nav-simple topics">
         {% for group in pkg.groups %}
         {% set sub_navs = h.get_pkg_dict_extra(c.pkg_dict, '__category_tag_' + group.id) %}
@@ -122,7 +122,7 @@
 {% if (c.pkg_dict.maintainer_email and c.pkg_dict.maintainer_email.strip()|length > 0) or (c.pkg_dict.maintainer and c.pkg_dict.maintainer.strip()|length > 0 ) or (h.get_pkg_dict_extra(c.pkg_dict, 'contact-email') and h.get_pkg_dict_extra(c.pkg_dict, 'contact-email').strip()|length > 0 ) %}
 <section class="module module-narrow contact">
     {% block contact_title %}
-    <h2 class="module-heading"><i class="icon-envelope-alt"></i>{{ _('Contact') }}</h2>
+    <h2 class="module-heading"><i class="fa fa-envelope"></i>{{ _('Contact') }}</h2>
     {% endblock %}
     {% block contact_content %}
     <p class="module-content">

--- a/ckanext/datagovtheme/templates/package/resource_read.html
+++ b/ckanext/datagovtheme/templates/package/resource_read.html
@@ -10,9 +10,9 @@
          href="{{ res.url }}"{% if h.is_web_format(c.resource) %} target="_blank"{% endif %}
          data-format="{{ (res.format or 'HTML')|lower }}" data-organization="{{ pkg.organization.title }}">
         {% if h.is_web_format(c.resource) %}
-          <i class="icon-external-link"></i> {{ _('Visit page') }}
+          <i class="fa fa-external-link-alt"></i>{{ _('Visit page') }}
         {% else %}
-          <i class="icon-download-alt"></i> {{ _('Download') }}
+          <i class="fa fa-download"></i>{{ _('Download') }}
         {% endif %}
       </a>
     </li>
@@ -32,7 +32,7 @@
     <div class="actions" style="padding-right: 40px">
       <li>
         <a class="btn btn-success" href="/viewer?{{ h.get_map_viewer_params(c.resource) }}">
-            <i class="icon-globe"></i> {{ _('View in Advanced Viewer') }}
+            <i class="fa fa-globe"></i> {{ _('View in Advanced Viewer') }}
         </a>
       </li>
     </div>
@@ -72,7 +72,7 @@
   {% block resource_read_title %}<h1 class="page-heading">{{ h.resource_display_name(res) | truncate(50) }}</h1>{% endblock %}
   {% block resource_read_url %}
     {% if res.url %}
-      <p class="muted ellipsis">{{ _('URL:') }} <a id="res_url" href="{{ res.url }}"
+      <p class="text-muted ellipsis">{{ _('URL:') }} <a id="res_url" href="{{ res.url }}"
      data-format="{{ (res.format or 'HTML')|lower }}" data-organization="{{ pkg.organization.title }}">{{ res.url }}</a></p>
     {% endif %}
   {% endblock %}

--- a/ckanext/datagovtheme/templates/package/search.html
+++ b/ckanext/datagovtheme/templates/package/search.html
@@ -3,9 +3,9 @@
 
 {% block breadcrumb %}
 
-<div class="module" style="margin:0px;">
+<div class="module">
 
-   <div class="faded disclaimer" style="margin-bottom:10px;visibility: hidden;height:0px;">
+   <div class="faded disclaimer">
         Federal datasets are subject to the U.S. Federal Government <a href="//www.data.gov/data-policy"><b>Data Policy</b></a>. Non-federal participants (e.g., universities, organizations, and tribal, state, and local governments) maintain their own data policies. Data policies influence the usefulness of the data. <a href="//www.data.gov/catalog-help"><b>Learn more</b></a> about how to search for data and use this catalog.
     </div>
 
@@ -45,7 +45,7 @@
                         {% endif %}
                       {{ label }}
                     {%- endif %}
-                    <a href="{{ c.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="icon-remove"></i></a>
+                    <a href="{{ c.remove_field(field, value) }}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
                   </span>
                 {% endfor %}
                 {% endif %}
@@ -126,7 +126,7 @@
 {% block secondary_content %}
 <section id="dataset-map" class="module module-narrow module-shallow">
     <h2 class="module-heading">
-        <i class="icon-medium icon-globe"></i>
+        <i class="icon-medium fa fa-globe"></i>
         {{ _('Filter by location') }}
         <a href="{{ h.remove_url_param(['ext_bbox','ext_prev_extent', 'ext_location']) }}" class="action">{{ _('Clear') }}</a>
     </h2>

--- a/ckanext/datagovtheme/templates/package/snippets/resource_extra_item.html
+++ b/ckanext/datagovtheme/templates/package/snippets/resource_extra_item.html
@@ -22,7 +22,7 @@
                         <p class="description"></p>
                         <div class="btn-group">
                         <a href="{{ url }}" class="btn btn-primary" target="_blank">
-                                <i class="icon-external-link"></i>
+                                <i class="fa fa-external-link-alt"></i>
                                 {% if title == 'API Endpoint' %}
                                         {{ _('URL') }}
                                 {% else %}

--- a/ckanext/datagovtheme/templates/package/snippets/resource_item.html
+++ b/ckanext/datagovtheme/templates/package/snippets/resource_item.html
@@ -45,12 +45,12 @@
   {% set archiver = res.archiver %}
   <div class="archiver {% if is_broken %}link-broken{% elif is_broken == None %}link-not-sure{% else %}link-not-broken{% endif %}" style='font-size:.8em; display:inline-block;'>
     {%- if archiver.is_broken == True -%}
-      <span class="icon icon-exclamation-sign text-error" ></span>
+      <span class="glyphicon glyphicon-exclamation-sign text-danger" ></span>
       {% trans %}<strong>Link is broken</strong>{% endtrans %}<br>
     {%- elif archiver.is_broken == None -%}
-      {% trans %}<strong><i class="icon-question-sign" style="color:orange;"></i> Link check is not conclusive</strong>{% endtrans %}<br>
+      {% trans %}<strong><i class="glyphicon glyphicon-question-sign" style="color:orange;"></i> Link check is not conclusive</strong>{% endtrans %}<br>
     {%- else-%}
-      {% trans %}<strong><i class="icon-ok-circle" style="color:green;"></i> Link is ok</strong>{% endtrans %}<br>
+      {% trans %}<strong><i class="glyphicon glyphicon-ok-circle" style="color:green;"></i> Link is ok</strong>{% endtrans %}<br>
     {% endif %}
   </div>
 {% endif %}
@@ -89,7 +89,7 @@
 	  <li class="arcgis"><a href="{{ arcgis_url }}?{{ arcgis_format_query }}={{ res.url }}"><span>ArcGIS</span></a></li>
 	  {% endif %}	  
 	</ul>
-	<a href="{{ resource_url }}" class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %} style="border-radius:4px;"> <i class="icon-globe"></i> {{ _('View Map') }} </a>
+	<a href="{{ resource_url }}" class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %} style="border-radius:4px;"> <i class="fa fa-globe"></i> {{ _('View Map') }} </a>
 
 {% elif is_web_format %}
 	{% if is_arcgis_format %}
@@ -101,7 +101,7 @@
 		  <li class="arcgis"><a href="{{ arcgis_url }}?url={{ res.url }}"><span>ArcGIS</span></a></li>
 		</ul>
 	{% endif %}
-	<a href="{{ resource_url }}" class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %}> <i class="icon-external-link"></i> {{ _('Visit page') }} </a>
+	<a href="{{ resource_url }}" class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %}><i class="fa fa-external-link-alt"></i>{{ _('Visit page') }} </a>
 
 {% elif is_preview_format %}
 	<button class="btn btn-primary btn-preview" data-toggle="dropdown" style="border-top-right-radius:0;border-bottom-right-radius:0">Open With
@@ -119,7 +119,7 @@
 	</ul>
 	<a href="{{ res.url }}" class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %} style="border-radius:4px;"
 	   data-format="{{ (res.format or 'HTML')|lower }}" data-organization="{{ pkg.organization.title }}"
-	> <i class="icon-download-alt"></i> {{ _('Download') }} </a>
+	> <i class="fa fa-download"></i></i> {{ _('Download') }} </a>
 
 {% elif is_cartodb_format and is_plotly_format  %}
 	<button class="btn btn-primary" data-toggle="dropdown" style="border-top-right-radius:0;border-bottom-right-radius:0">Open With
@@ -132,7 +132,7 @@
 	</ul>
 	<a href="{{ resource_url }}"
 	   data-format="{{ (res.format or 'HTML')|lower }}" data-organization="{{ pkg.organization.title }}"
-	   class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %}> <i class="icon-download-alt"></i> {{ _('Download') }} </a>
+	   class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %}> <i class="fa fa-download"></i> {{ _('Download') }} </a>
 {% elif is_cartodb_format %}
 	<button class="btn btn-primary" data-toggle="dropdown" style="border-top-right-radius:0;border-bottom-right-radius:0">Open With
 	</button>
@@ -143,7 +143,7 @@
 	</ul>
 	<a href="{{ resource_url }}" class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %}
 	   data-format="{{ (res.format or 'HTML')|lower }}" data-organization="{{ pkg.organization.title }}"
-	> <i class="icon-download-alt"></i> {{ _('Download') }} </a>
+	> <i class="fa fa-download"></i></i> {{ _('Download') }} </a>
 {% elif is_plotly_format %}
 	<button class="btn btn-primary" data-toggle="dropdown" style="border-top-right-radius:0;border-bottom-right-radius:0">Open With
 	</button>
@@ -154,11 +154,11 @@
 	</ul>
 	<a href="{{ resource_url }}" class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %}
 	   data-format="{{ (res.format or 'HTML')|lower }}" data-organization="{{ pkg.organization.title }}"
-	> <i class="icon-download-alt"></i> {{ _('Download') }} </a>
+	> <i class="fa fa-download"></i></i> {{ _('Download') }} </a>
 {% else %}
 	<a href="{{ resource_url }}" class="btn btn-primary"{% if is_web_format %} target="_blank"{% endif %}
 	   data-format="{{ (res.format or 'HTML')|lower }}" data-organization="{{ pkg.organization.title }}"
-	> <i class="icon-download-alt"></i> {{ _('Download') }} </a>
+	> <i class="fa fa-download"></i>{{ _('Download') }} </a>
 {% endif %}
 </div>
 {% endblock %}

--- a/ckanext/datagovtheme/templates/package/snippets/resources_list.html
+++ b/ckanext/datagovtheme/templates/package/snippets/resources_list.html
@@ -30,10 +30,10 @@ Example:
       <br/>
       <!-- display new msg for all non-public datasets -->
       {% if (h.get_pkg_dict_extra(pkg, 'accessLevel') == 'non-public') %}
-        <div class="no-resource"><i class="icon-exclamation-sign"></i>No file downloads are available because this is not a public dataset. See Access &amp; Use Information for details.</div>
+        <div class="no-resource"><i class="glyphicon glyphicon-exclamation-sign"></i>No file downloads are available because this is not a public dataset. See Access &amp; Use Information for details.</div>
       <!--  for datasets that are NOT non-public, only display old message when there are no resources-->
       {% elif not resources %}
-        <div class="no-resource"><i class="icon-exclamation-sign"></i>No file downloads have been provided. The publisher may provide downloads in the future or they may be available from their other links.</div>
+        <div class="no-resource"><i class="glyphicon glyphicon-exclamation-sign"></i>No file downloads have been provided. The publisher may provide downloads in the future or they may be available from their other links.</div>
       <!--  so we are dealing with a dataset that is either public/restricted... and it has resources.. display the resources -->
       {% else %}
         {% for resource in resources %}
@@ -54,9 +54,9 @@ Example:
   <section id="dataset-resources" class="resources module-content">
     <h3>{{ _('Downloads & Resources') }}</h3>
     {% if (h.get_pkg_dict_extra(pkg, 'accessLevel') == 'non-public') %}
-      <div class="no-resource"><i class="icon-exclamation-sign"></i>No file downloads are available because this is not a public dataset. See Access &amp; Use Information for details.</div>
+      <div class="no-resource"><i class="glyphicon glyphicon-exclamation-sign"></i>No file downloads are available because this is not a public dataset. See Access &amp; Use Information for details.</div>
     {% else %}
-      <div class="no-resource"><i class="icon-exclamation-sign"></i>No file downloads have been provided. The publisher may provide downloads in the future or they may be available from their other links.</div>
+      <div class="no-resource"><i class="glyphicon glyphicon-exclamation-sign"></i>No file downloads have been provided. The publisher may provide downloads in the future or they may be available from their other links.</div>
     {% endif %}
   </section>
 {% endif %}

--- a/ckanext/datagovtheme/templates/package/snippets/search_form.html
+++ b/ckanext/datagovtheme/templates/package/snippets/search_form.html
@@ -45,7 +45,7 @@
             {% endif %}
             {{ label }}
           {% endif %}
-          <a href="{{c.remove_field(field, value)}}" class="remove" title="{{ _('Remove') }}"><i class="icon-remove"></i></a>
+          <a href="{{c.remove_field(field, value)}}" class="remove" title="{{ _('Remove') }}"><i class="fa fa-times"></i></a>
         </span>
       {% endfor %}
     {% endfor %}

--- a/ckanext/datagovtheme/templates/related/snippets/related_item.html
+++ b/ckanext/datagovtheme/templates/related/snippets/related_item.html
@@ -35,9 +35,9 @@ Example:
     {% if related.description %}
       <div class="prose">{{ h.render_markdown(related.description) }}</div>
     {% endif %}
-    <a class="btn btn-small btn-primary" href="{{ related.url }}" target="_blank">{{ _('Go to {type}').format(type=related.type|replace('_', ' ')|title) }}</a>
+    <a class="btn btn-sm btn-primary" href="{{ related.url }}" target="_blank">{{ _('Go to {type}').format(type=related.type|replace('_', ' ')|title) }}</a>
     {% if pkg_id %}
-      {{ h.nav_link(_('Edit'), controller='related', action='edit', id=pkg_id, related_id=related.id, class_='btn btn-small') }}
+      {{ h.nav_link(_('Edit'), controller='related', action='edit', id=pkg_id, related_id=related.id, class_='btn btn-sm') }}
     {% endif %}
   </div>
 </li>

--- a/ckanext/datagovtheme/templates/snippets/facet_list.html
+++ b/ckanext/datagovtheme/templates/snippets/facet_list.html
@@ -46,7 +46,7 @@ hide_empty
 
     <section class="{{ wrapper_class or 'module module-narrow module-shallow' }}">
       <h2 class="module-heading" id="sec-{{name}}">
-        <i class="icon-medium icon-filter"></i>
+        <i class="fa fa-filter"></i>
         {% set title = title or h.get_facet_title(name) %}
           {% if title == 'Progress' %}
           {% set title = 'Status' %}

--- a/ckanext/datagovtheme/templates/snippets/home_breadcrumb_item.html
+++ b/ckanext/datagovtheme/templates/snippets/home_breadcrumb_item.html
@@ -1,2 +1,2 @@
 {# Used to insert the home icon into a breadcrumb #}
-<li class="home"><a href="{{ h.url(controller='package', action='search') }}"><i class="icon-home"></i><span> {{ _('Home') }}</span></a></li>
+<li class="home"><a href="{{ h.url(controller='package', action='search') }}"><i class="fa fa-home"></i><span> {{ _('Home') }}</span></a></li>

--- a/ckanext/datagovtheme/templates/snippets/organization.html
+++ b/ckanext/datagovtheme/templates/snippets/organization.html
@@ -85,7 +85,7 @@ Example:
     {% set organization_terms = organization.terms_of_use %}
         {% if organization_terms %}
             <section class="module module-narrow module-shallow terms">
-                <h2 class="module-heading"><i class="icon-medium icon-legal"></i>{{ _('Terms of Use') }}</h2>
+                <h2 class="module-heading"><i class="fa fa-legal"></i>{{ _('Terms of Use') }}</h2>
                     <p class="module-content">
                         <a href="{{organization.terms_of_use}}"> Terms of Use</a>
                     </p>

--- a/ckanext/datagovtheme/templates/snippets/package_item.html
+++ b/ckanext/datagovtheme/templates/snippets/package_item.html
@@ -25,7 +25,9 @@ Example:
 <li class="{{ item_class or "dataset-item" }}{% if organization %} has-organization{% endif %}">
   {% block package_item_content %}
     <div class="dataset-content">
+      {% if organization %}
       {% set organization_type = organization.organization_type|replace(' Government', '') %}
+      {% endif %}
       {% if organization_type and show_organization %}
         <div class="organization-type-wrap">
         <span class="organization-type" title="{{ organization.organization_type }}" data-organization-type="{{ organization_type|lower }}">
@@ -36,13 +38,13 @@ Example:
       <h3 class="dataset-heading">
         {% if package.private %}
           <span class="dataset-private label label-inverse">
-            <i class="icon-lock"></i>
+            <i class="fa fa-lock"></i>
             {{ _('Private') }}
           </span>
         {% endif %}
 
         {% if h.get_pkg_dict_extra(package, 'collection_metadata', '') %}
-            <span class="dataset-collection label">
+            <span class="dataset-collection label label-default">
                 <i class="icon-collection"></i>
                 {{ _('Collection') }}
             </span>
@@ -52,7 +54,7 @@ Example:
         {% if package.get('state', '').startswith('draft') %}
           <span class="label label-info">{{ _('Draft') }}</span>
         {% elif package.get('state', '').startswith('deleted') %}
-          <span class="label label-important">{{ _('Deleted') }}</span>
+          <span class="label label-danger">{{ _('Deleted') }}</span>
         {% endif %}
         {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
       </h3>
@@ -73,7 +75,7 @@ Example:
             {% if loop.index < resource_limit %}
               {% set url = h.url_for(controller='package', action='resource_read', id=package.name, resource_id=resource.id) if is_map_format else resource.url %}
               <li>
-                <a href="{{ url }}" class="label" data-format="{{ format|lower }}" {% if is_web_format %} target="_blank"{% endif %}
+                <a href="{{ url }}" class="label label-default" data-format="{{ format|lower }}" {% if is_web_format %} target="_blank"{% endif %}
                    data-organization="{{ package.organization.title }}">{{ format }}</a>
               </li>
             {% elif loop.index == resource_limit %}

--- a/ckanext/datagovtheme/templates/snippets/root_nav.html
+++ b/ckanext/datagovtheme/templates/snippets/root_nav.html
@@ -1,27 +1,29 @@
 {% set menus = h.get_dynamic_menu() %}
-<button type="button" class="btn btn-navbar" data-toggle="collapse" data-target=".nav-primary">
-    <span class="icon-bar"></span>
-    <span class="icon-bar"></span>
-    <span class="icon-bar"></span>
+<button type="button" class="navbar-toggle" data-toggle="collapse" data-target="#nav-primary" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+  <span class="icon-bar"></span>
+  <span class="icon-bar"></span>
+  <span class="icon-bar"></span>
 </button>
-<div class="nav-primary nav-collapse collapse">
-    <nav class="primary">
+<div class="nav-primary navbar-collapse collapse" id="nav-primary">
+  <nav class="primary">
     <ul class="nav navbar-nav navbar-right" id="menu-primary-navigation">
       {% for menu_1 in menus['primary_navigation'] if not menu_1['parent_id'] %}
-        {% if menu_1['name'] == 'Data' %}
-          <li class="active"><a href="/dataset">Data</a></li>
-        {% elif menu_1['name'] == 'Topics' %}
-          <li class="dropdown yamm-fw menu-topics"><a class="dropdown-toggle" data-toggle="dropdown">Topics<b class="caret"></b></a>
-            <ul class="dropdown-menu topics">
-              {% for menu_2 in menus['primary_navigation'] if menu_2['parent_id'] == menu_1['id'] %}
-                <li class="menu-{{ menu_2['name'].lower().replace(" & ", "-").replace(" ", "-") }}"><a href="{{ menu_2['link'] }}"><i></i><span>{{ menu_2['name'] }}</span></a></li>
-              {% endfor %}
-            </ul>
-          <li>
+      {% if menu_1['name'] == 'Data' %}
+      <li class="active"><a href="/dataset">Data</a></li>
+      {% elif menu_1['name'] == 'Topics' %}
+      <li class="dropdown yamm-fw menu-topics"><a class="dropdown-toggle" data-toggle="dropdown">Topics<b
+            class="caret"></b></a>
+        <ul class="dropdown-menu topics">
+          {% for menu_2 in menus['primary_navigation'] if menu_2['parent_id'] == menu_1['id'] %}
+          <li class="menu-{{ menu_2['name'].lower().replace(" & ", "-").replace(" ", "-") }}"><a
+              href="{{ menu_2['link'] }}"><i></i><span>{{ menu_2['name'] }}</span></a></li>
+          {% endfor %}
+        </ul>
+      <li>
         {% else %}
-          <li><a href="{{ menu_1['link'] }}">{{ menu_1['name'] }}</a></li>
-        {% endif %}
+      <li><a href="{{ menu_1['link'] }}">{{ menu_1['name'] }}</a></li>
+      {% endif %}
       {% endfor %}
     </ul>
-    </nav>
+  </nav>
 </div>

--- a/ckanext/datagovtheme/templates/snippets/social.html
+++ b/ckanext/datagovtheme/templates/snippets/social.html
@@ -1,9 +1,9 @@
 {% set current_url = h.full_current_url() %}
 <section class="module module-narrow social">
-<h2 class="module-heading"><i class="icon-medium icon-share"></i> {{ _('Share on Social Sites') }}</h2>
+<h2 class="module-heading"><i class="fa fa-share"></i>{{ _('Share on Social Sites') }}</h2>
   <ul class="nav nav-simple">
-    <li class="nav-item"><a href="https://plus.google.com/share?url={{ current_url }}" target="_blank"><i class="icon-google-plus-sign"></i> Google+</a></li>
-    <li class="nav-item"><a href="https://twitter.com/share?url={{ current_url }}" target="_blank"><i class="icon-twitter-sign"></i> Twitter</a></li>
-    <li class="nav-item"><a href="https://www.facebook.com/sharer.php?u={{ current_url }}" target="_blank"><i class="icon-facebook-sign"></i> Facebook</a></li>
+    <li class="nav-item"><a href="https://plus.google.com/share?url={{ current_url }}" target="_blank"><i class="fab fa-google-plus-g"></i> Google+</a></li>
+    <li class="nav-item"><a href="https://twitter.com/share?url={{ current_url }}" target="_blank"><i class="fab fa-twitter"></i>Twitter</a></li>
+    <li class="nav-item"><a href="https://www.facebook.com/sharer.php?u={{ current_url }}" target="_blank"><i class="fab fa-facebook"></i>Facebook</a></li>
   </ul>
 </section>

--- a/ckanext/datagovtheme/templates/snippets/sort_by.html
+++ b/ckanext/datagovtheme/templates/snippets/sort_by.html
@@ -8,9 +8,9 @@ Example:
   {% snippet 'snippets/sort_by.html', sort=c.sort_by_selected %}
 
 #}
-<span class="form-select control-group control-order-by">
+<span class="form-select form-group control-order-by">
   <label for="field-order-by">{{ _('Order by') }}</label>
-  <select id="field-order-by" name="sort">
+  <select id="field-order-by" name="sort" class="form-control">
     <option value="score desc, name asc"{% if sort =='score desc, name asc' %} selected="selected"{% endif %}>{{ _('Relevance') }}</option>
     <option value="title_string asc"{% if sort=='title_string asc' %} selected="selected"{% endif %}>{{ _('Name Ascending') }}</option>
     <option value="title_string desc"{% if sort=='title_string desc' %} selected="selected"{% endif %}>{{ _('Name Descending') }}</option>

--- a/ckanext/datagovtheme/templates/user/dashboard.html
+++ b/ckanext/datagovtheme/templates/user/dashboard.html
@@ -4,7 +4,7 @@
   {% set organizations = h.organizations_available(permission='read') %}
   <div class="module module-narrow module-shallow">
     <h2 class="module-heading">
-      <i class="icon-building"></i>
+      <i class="fa fa-building"></i>
       {{ _('My Organizations') }}
     </h2>
     {% if organizations %}

--- a/ckanext/datagovtheme/tests/test_datagovetheme.py
+++ b/ckanext/datagovtheme/tests/test_datagovetheme.py
@@ -1,0 +1,21 @@
+# encoding: utf-8
+
+'''Tests for the ckanext.datagovtheme extension.
+
+'''
+from bs4 import BeautifulSoup
+from nose.tools import assert_true
+
+import ckan.tests.helpers as helpers
+
+
+class TestDatagovthemeServed(helpers.FunctionalTestBase):
+    '''Tests for the ckanext.datagovtheme.plugin module.'''
+
+    def test_datagovtheme_css(self):
+        app = helpers._get_test_app()
+
+        index_response = app.get('/')
+
+        assert_true('datagovtheme.js' in index_response)
+        assert_true('datagovtheme.css' in index_response)

--- a/ckanext/datagovtheme/tests/test_datagovetheme.py
+++ b/ckanext/datagovtheme/tests/test_datagovetheme.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup
 from nose.tools import assert_true
 
 import ckan.tests.helpers as helpers
+import ckan.plugins
 
 
 class TestDatagovthemeServed(helpers.FunctionalTestBase):

--- a/ckanext/datagovtheme/tests/test_datagovetheme.py
+++ b/ckanext/datagovtheme/tests/test_datagovetheme.py
@@ -20,5 +20,4 @@ class TestDatagovthemeServed(helpers.FunctionalTestBase):
 
         index_response = app.get('/')
 
-        assert_true('datagovtheme.js' in index_response)
-        assert_true('datagovtheme.css' in index_response)
+        assert_true('main.min.css' in index_response)

--- a/ckanext/datagovtheme/tests/test_datagovetheme.py
+++ b/ckanext/datagovtheme/tests/test_datagovetheme.py
@@ -13,7 +13,7 @@ class TestDatagovthemeServed(helpers.FunctionalTestBase):
     '''Tests for the ckanext.datagovtheme.plugin module.'''
     
     def plugin_loaded(self):
-        assert_true(ckan.plugins.plugin_loaded('datagovtheme'))
+        assert_true(ckan.plugins.test_plugin_loaded('datagovtheme'))
 
     def test_datagovtheme_css(self):
         app = helpers._get_test_app()

--- a/ckanext/datagovtheme/tests/test_datagovetheme.py
+++ b/ckanext/datagovtheme/tests/test_datagovetheme.py
@@ -3,14 +3,12 @@
 '''Tests for the ckanext.datagovtheme extension.
 
 '''
-from bs4 import BeautifulSoup
 from nose.tools import assert_true
 
-import ckan.tests.helpers as helpers
 import ckan.plugins
+from ckantoolkit.tests.helpers import _get_test_app, FunctionalTestBase
 
-
-class TestDatagovthemeServed(helpers.FunctionalTestBase):
+class TestDatagovthemeServed(FunctionalTestBase):
     '''Tests for the ckanext.datagovtheme.plugin module.'''
     
     def test_plugin_loaded(self):
@@ -23,7 +21,7 @@ class TestDatagovthemeServed(helpers.FunctionalTestBase):
     def test_datagovtheme_css(self):
         ckan.plugins.load('geodatagov')
         ckan.plugins.load('datagovtheme')
-        app = helpers._get_test_app()
+        app = _get_test_app()
 
         index_response = app.get('/')
 

--- a/ckanext/datagovtheme/tests/test_datagovetheme.py
+++ b/ckanext/datagovtheme/tests/test_datagovetheme.py
@@ -3,26 +3,38 @@
 '''Tests for the ckanext.datagovtheme extension.
 
 '''
-from nose.tools import assert_true
+from nose.tools import assert_true, assert_in
 
-import ckan.plugins
+from ckan import plugins as p
+from ckan.plugins import toolkit
 from ckantoolkit.tests.helpers import _get_test_app, FunctionalTestBase
 
 class TestDatagovthemeServed(FunctionalTestBase):
     '''Tests for the ckanext.datagovtheme.plugin module.'''
     
-    def test_plugin_loaded(self):
-        ckan.plugins.load('geodatagov')
-        assert_true(ckan.plugins.plugin_loaded('geodatagov'))
+    @classmethod
+    def setup_class(cls):
+        super(TestDatagovthemeServed, cls).setup_class()
 
-        ckan.plugins.load('datagovtheme')
-        assert_true(ckan.plugins.plugin_loaded('datagovtheme'))
+        if not p.plugin_loaded('geodatagov'):
+            p.load('geodatagov')
+
+        if not p.plugin_loaded('datagovtheme'):
+            p.load('datagovtheme')
+
+    @classmethod
+    def teardown_class(cls):
+        super(TestDatagovthemeServed, cls).teardown_class()
+        p.unload('geodatagov')
+        p.unload('datagovtheme')
+
+    def test_plugin_loaded(self):
+        assert_true(p.plugin_loaded('datagovtheme'))
+        assert_true(p.plugin_loaded('geodatagov'))
 
     def test_datagovtheme_css(self):
-        ckan.plugins.load('geodatagov')
-        ckan.plugins.load('datagovtheme')
-        app = _get_test_app()
+        app = self._get_test_app()
 
-        index_response = app.get('/')
+        index_response = app.get('/dataset')
 
-        assert_true('main.min.css' in index_response)
+        assert_in('datagovtheme.css', index_response.unicode_body)

--- a/ckanext/datagovtheme/tests/test_datagovetheme.py
+++ b/ckanext/datagovtheme/tests/test_datagovetheme.py
@@ -11,6 +11,9 @@ import ckan.tests.helpers as helpers
 
 class TestDatagovthemeServed(helpers.FunctionalTestBase):
     '''Tests for the ckanext.datagovtheme.plugin module.'''
+    
+    def plugin_loaded(self):
+        assert_true(ckan.plugins.plugin_loaded('datagovtheme'))
 
     def test_datagovtheme_css(self):
         app = helpers._get_test_app()

--- a/ckanext/datagovtheme/tests/test_datagovetheme.py
+++ b/ckanext/datagovtheme/tests/test_datagovetheme.py
@@ -13,9 +13,15 @@ class TestDatagovthemeServed(helpers.FunctionalTestBase):
     '''Tests for the ckanext.datagovtheme.plugin module.'''
     
     def test_plugin_loaded(self):
-        assert_true(ckan.plugins.test_plugin_loaded('datagovtheme'))
+        ckan.plugins.load('geodatagov')
+        assert_true(ckan.plugins.plugin_loaded('geodatagov'))
+
+        ckan.plugins.load('datagovtheme')
+        assert_true(ckan.plugins.plugin_loaded('datagovtheme'))
 
     def test_datagovtheme_css(self):
+        ckan.plugins.load('geodatagov')
+        ckan.plugins.load('datagovtheme')
         app = helpers._get_test_app()
 
         index_response = app.get('/')

--- a/ckanext/datagovtheme/tests/test_datagovetheme.py
+++ b/ckanext/datagovtheme/tests/test_datagovetheme.py
@@ -12,7 +12,7 @@ import ckan.tests.helpers as helpers
 class TestDatagovthemeServed(helpers.FunctionalTestBase):
     '''Tests for the ckanext.datagovtheme.plugin module.'''
     
-    def plugin_loaded(self):
+    def test_plugin_loaded(self):
         assert_true(ckan.plugins.test_plugin_loaded('datagovtheme'))
 
     def test_datagovtheme_css(self):

--- a/test.ini
+++ b/test.ini
@@ -1,0 +1,2 @@
+[app:main]
+use = config:../ckan/test-core.ini

--- a/test.ini
+++ b/test.ini
@@ -1,2 +1,3 @@
 [app:main]
 use = config:../ckan/test-core.ini
+ckanext.geodatagov.dynamic_menu.url_default = http://www.data.gov/app/plugins/datagov-custom/wp_download_links.php


### PR DESCRIPTION
Most of the changes here are in the main datagovtheme.css file. I tried to use this as much as possible rather than changing the templates. Most of the template changes are to switch over to using FontAwesome. There are a couple instances of using Glyphyicons in cases where the FontAwesome icons look look drastically different than the originals. The recommendation by Bootstrap versions 3 and up is to use FontAwesome.