### PR TITLE
Fix CKAN 2.3

### DIFF
--- a/ckanext/datagovtheme/controllers.py
+++ b/ckanext/datagovtheme/controllers.py
@@ -1,12 +1,17 @@
+import logging
 import urllib
+
 import ckan.plugins as p
-from ckan.plugins.toolkit import config
+from ckan.plugins.toolkit import check_ckan_version
 import ckan.lib.helpers as h, json
 from ckan.lib.base import BaseController, c, \
                           request, response, abort, redirect
 
+if check_ckan_version(min_version='2.8'):
+    from ckan.plugins.toolkit import config
+else:
+    from pylons import config
 
-import logging
 log = logging.getLogger(__name__)
 
 class ViewController(BaseController):

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -4,11 +4,17 @@ import logging
 import csv
 import StringIO
 
-from ckan.plugins.toolkit import config, request
+from ckan.plugins.toolkit import check_ckan_version, request
 
 from ckan import plugins as p
 from ckan.lib import helpers as h
 from ckanext.geodatagov.plugins import RESOURCE_MAPPING
+
+if check_ckan_version(min_version='2.8'):
+    from ckan.plugins.toolkit import config
+else:
+    from pylons import config
+
 
 log = logging.getLogger(__name__)
 ckan_tmp_path = '/var/tmp/ckan'


### PR DESCRIPTION
CKAN 2.3 plugin.toolkit does not have config available. Use the old way of
getting it through pylons.