### PR TITLE
Allow config to avoid using some extensions

### DIFF
--- a/ckanext/datagovtheme/templates/package/resource_read.html
+++ b/ckanext/datagovtheme/templates/package/resource_read.html
@@ -22,8 +22,6 @@
     <li>{% snippet 'package/snippets/data_api_button.html', resource=res, datastore_root_url=c.datastore_api %}</li>
   {% endif %}
   <br><br>
-  {{ h.archiver_is_resource_broken_line(c.resource) }}
-  {{ h.qa_openness_stars_resource_line(c.resource) }}
   <p style="height:0%; margin:1.5%;"></p>
   <a onClick="document.getElementById('archive_table').scrollIntoView(false);" style="color:#187794; cursor:pointer;"><strong>More Details</strong></a>
 {% endblock %}
@@ -137,11 +135,6 @@
     </section>
     {% resource 'datagovtheme/qa.js' %}
     <link rel="stylesheet" href="/css/qa.css" />
-    <div class="col-sm-12" id="archive_table">
-      {{ h.archiver_resource_info_table(c.resource) }}
-      {{ h.qa_openness_stars_resource_table(c.resource) }}
-    <br>
-   </div>
  {% endif %}  
 {% endblock %}
 


### PR DESCRIPTION
This allows new catalog to run with upstream archiver ext
The new catalog now uses `ckanext-arcvhiver` from upstream. At upstream we don't have some functions required here.
If this PR is approved we will need an issue to track the upgrade of `ckanext-arcvhiver` with this new features.

Fixes errors:
 - [#1690](https://github.com/GSA/datagov-deploy/issues/1690)
 - [#46](https://github.com/GSA/catalog.data.gov/issues/46)

Need to open a new issue to recover this after upgrade `archiver` ext