### PR TITLE
use config to avoid UI errors with upstreramed extensions

### DIFF
--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -532,3 +532,10 @@ def get_bureau_info(bureau_code):
 
 def is_bootstrap2():
     return not p.toolkit.check_ckan_version(min_version='2.8')
+
+def use_extension(ext_name, default=True):
+    """ to use or not an extension in UI 
+        (Not used for all cases, just to avoid errors while CKAN 2.8 migration) """
+    use = config.get('ckanext.geodatagov.use.{}', default)
+    
+    return use

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -3,6 +3,7 @@ import os, time
 import logging
 import csv
 import StringIO
+import six
 
 from ckan import plugins as p
 from ckan.lib import helpers as h
@@ -533,9 +534,24 @@ def get_bureau_info(bureau_code):
 def is_bootstrap2():
     return not p.toolkit.check_ckan_version(min_version='2.8')
 
+def asbool(obj):
+    # fails (?) from ckan import common as asbool
+    truthy = frozenset([u'true', u'yes', u'on', u'y', u't', u'1'])
+    falsy = frozenset([u'false', u'no', u'off', u'n', u'f', u'0'])
+
+    if isinstance(obj, six.string_types):
+        obj = obj.strip().lower()
+        if obj in truthy:
+            return True
+        elif obj in falsy:
+            return False
+        else:
+            raise ValueError(u"String is not true/false: {}".format(obj))
+    return bool(obj)
+
 def use_extension(ext_name, default=True):
     """ to use or not an extension in UI 
         (Not used for all cases, just to avoid errors while CKAN 2.8 migration) """
-    use = config.get('ckanext.geodatagov.use.{}', default)
-    
-    return use
+    use = config.get('ckanext.datagovtheme.use.{}'.format(ext_name), default)
+
+    return asbool(use)

--- a/ckanext/datagovtheme/plugin.py
+++ b/ckanext/datagovtheme/plugin.py
@@ -106,4 +106,5 @@ class DatagovTheme(p.SingletonPlugin):
             'schema11_frequency_mod':datagovtheme_helpers.schema11_frequency_mod,
             'convert_top_category_to_list':datagovtheme_helpers.convert_top_category_to_list,
             'is_bootstrap2':datagovtheme_helpers.is_bootstrap2,
+            'use_extension':datagovtheme_helpers.use_extension,
         }

--- a/ckanext/datagovtheme/templates/package/resource_read.html
+++ b/ckanext/datagovtheme/templates/package/resource_read.html
@@ -22,8 +22,8 @@
     <li>{% snippet 'package/snippets/data_api_button.html', resource=res, datastore_root_url=c.datastore_api %}</li>
   {% endif %}
   <br><br>
-  {{ h.archiver_is_resource_broken_line(c.resource) }}
-  {{ h.qa_openness_stars_resource_line(c.resource) }}
+  {% if h.use_extension('archiver') %}{{ h.archiver_is_resource_broken_line(c.resource) }}{% endif %}
+  {% if h.use_extension('qa') %}{{ h.qa_openness_stars_resource_line(c.resource) }}{% endif %}
   <p style="height:0%; margin:1.5%;"></p>
   <a onClick="document.getElementById('archive_table').scrollIntoView(false);" style="color:#187794; cursor:pointer;"><strong>More Details</strong></a>
 {% endblock %}
@@ -138,8 +138,8 @@
     {% resource 'datagovtheme/qa.js' %}
     <link rel="stylesheet" href="/css/qa.css" />
     <div class="col-sm-12" id="archive_table">
-      {{ h.archiver_resource_info_table(c.resource) }}
-      {{ h.qa_openness_stars_resource_table(c.resource) }}
+      {% if h.use_extension('archiver') %} {{ h.archiver_resource_info_table(c.resource) }} {% endif %}
+      {% if h.use_extension('qa') %}{{ h.qa_openness_stars_resource_table(c.resource) }} {% endif %}
     <br>
    </div>
  {% endif %}  


### PR DESCRIPTION
This allows new catalog to run with upstream versions of `archiver` and `qa` ext. At upstream we don't have some functions required here.

Fixes errors:
 - [#1690](https://github.com/GSA/datagov-deploy/issues/1690)
 - [#46](https://github.com/GSA/catalog.data.gov/issues/46)

Need to open a new issue to recover this after upgrade `archiver` and `qa` extensions

Requiere
 - Config at new catalog `ckanext.geodatagov.use.archiver=False`
 - Config at new catalog `ckanext.geodatagov.use.qa=False`

Tested in the new catalog.
![image](https://user-images.githubusercontent.com/3237309/83422768-66ceb700-a400-11ea-9eaf-0c5d0559801f.png)
