### PR TITLE
Fix shapely lib error by installing geos and py-cryptography

### DIFF
--- a/ckan-docker/Dockerfile
+++ b/ckan-docker/Dockerfile
@@ -1,6 +1,17 @@
 FROM openknowledge/ckan-dev:2.8
-
 MAINTAINER Your Name Here <you@example.com>
+
+RUN apk add py-cryptography
+
+# Fix shapely lib error. Install geos
+# TODO consider moving to Alpine>=3.11 or to Bionic
+
+ADD http://download.osgeo.org/geos/geos-3.7.0.tar.bz2 /geos/geos.tar.bz2
+RUN tar xf /geos/geos.tar.bz2 -C /geos --strip-components=1
+RUN cd /geos && \
+    ./configure && \
+    make -j 1 && \
+    make install
 
 # Install any extensions needed by your CKAN instance
 # (Make sure to add the plugins to CKAN__PLUGINS in the .env file)


### PR DESCRIPTION
Fix shapely lib error by installing geos and py-cryptography