### PR TITLE
Use new ckan function for showing package "notes"

### DIFF
--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -35,11 +35,9 @@
 		
 	{# <h4> {{ pkg }}</h4> #}
     {% block package_notes %}
-      {% if c.pkg_notes_formatted %}
-        <div itemprop="description" class="notes embedded-content">
-          {{ c.pkg_notes_formatted }}
+      <div itemprop="description" class="notes embedded-content">
+          {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
         </div>
-      {% endif %}
     {% endblock %}
     {# FIXME why is this here? seems wrong #}
     <span class="insert-comment-thread"></span>

--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -33,13 +33,12 @@
     {% endif %}
     <br clear="all" />
 		
-	{# <h4> {{ pkg }}</h4> #}
-    {% block package_notes %}
+	  {% block package_notes %}
       <div itemprop="description" class="notes embedded-content">
           {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
         </div>
     {% endblock %}
-    {# FIXME why is this here? seems wrong #}
+  
     <span class="insert-comment-thread"></span>
 </section>
 {% endblock %}


### PR DESCRIPTION
Related to [DataGovCatalog#6](https://github.com/GSA/ckanext-datagovcatalog/issues/6)

This PR:

 - Use the CKAN function to render notes

Working locally:

![image](https://user-images.githubusercontent.com/3237309/90805328-d8c4e700-e2f1-11ea-9945-89acdfd56ec2.png)
