### PR TITLE
Override helper to get the rigth info about extras

### DIFF
--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -582,7 +582,7 @@ def get_pkg_dict_extra(pkg_dict, key, default=None):
             rolledup_extras = json.loads(extra.get('value'))
             for k, value in rolledup_extras.iteritems():
                 if k == key: 
-                    return v
+                    return value
     
     # Also include harvest information if exists
     if key in ['harvest_object_id', 'harvest_source_id', 'harvest_source_title']:

--- a/ckanext/datagovtheme/plugin.py
+++ b/ckanext/datagovtheme/plugin.py
@@ -107,4 +107,5 @@ class DatagovTheme(p.SingletonPlugin):
             'convert_top_category_to_list':datagovtheme_helpers.convert_top_category_to_list,
             'is_bootstrap2':datagovtheme_helpers.is_bootstrap2,
             'use_extension':datagovtheme_helpers.use_extension,
+            'get_pkg_dict_extra': datagovtheme_helpers.get_pkg_dict_extra,
         }


### PR DESCRIPTION
Realted to [Multi#373](https://github.com/GSA/datagov-ckan-multi/issues/373) and [Catalog#7](https://github.com/GSA/ckanext-datagovcatalog/issues/7)

This PR:
 - Fix both issues
 - Override the helper to get extras about packages to include _rolled up_ ones and harvest source information.

![image](https://user-images.githubusercontent.com/3237309/91579021-61aad680-e921-11ea-94e6-897cd5d02817.png)
