### PR TITLE
Skip overriding helpers. This fails in CKAN 2.3

### DIFF
--- a/ckanext/datagovtheme/plugin.py
+++ b/ckanext/datagovtheme/plugin.py
@@ -84,7 +84,7 @@ class DatagovTheme(p.SingletonPlugin):
     ## ITemplateHelpers
     def get_helpers(self):
         from ckanext.datagovtheme import helpers as datagovtheme_helpers
-        return {
+        helpers = {
             'render_datetime_datagov': datagovtheme_helpers.render_datetime_datagov,
             'get_harvest_object_formats': datagovtheme_helpers.get_harvest_object_formats,
             'get_dynamic_menu': datagovtheme_helpers.get_dynamic_menu,
@@ -107,8 +107,17 @@ class DatagovTheme(p.SingletonPlugin):
             'convert_top_category_to_list':datagovtheme_helpers.convert_top_category_to_list,
             'is_bootstrap2':datagovtheme_helpers.is_bootstrap2,
             'get_pkg_dict_extra': datagovtheme_helpers.get_pkg_dict_extra,
-            'archiver_resource_info_table': datagovtheme_helpers.archiver_resource_info_table,
-            'archiver_is_resource_broken_line': datagovtheme_helpers.archiver_is_resource_broken_line,
-            'qa_openness_stars_resource_line': datagovtheme_helpers.qa_openness_stars_resource_line,
-            'qa_openness_stars_resource_table': datagovtheme_helpers.qa_openness_stars_resource_table,
         }
+        if p.toolkit.check_ckan_version(min_version='2.8'):
+            # old CKAN don't allow to override helpers
+            # https://github.com/GSA/ckan/blob/datagov/ckan/config/environment.py#L70:L70
+            override_helpers = {
+                'archiver_resource_info_table': datagovtheme_helpers.archiver_resource_info_table,
+                'archiver_is_resource_broken_line': datagovtheme_helpers.archiver_is_resource_broken_line,
+                'qa_openness_stars_resource_line': datagovtheme_helpers.qa_openness_stars_resource_line,
+                'qa_openness_stars_resource_table': datagovtheme_helpers.qa_openness_stars_resource_table,
+            }
+
+            helpers.update(override_helpers)
+        
+        return helpers


### PR DESCRIPTION
Fix error in [CKAN 2.3](https://github.com/GSA/ckan/blob/datagov/ckan/config/environment.py#L70:L70)

```
app_1       | Traceback (most recent call last):
app_1       |   File "/usr/bin/ckan", line 59, in <module>
app_1       |     load_entry_point('PasteScript', 'console_scripts', 'paster')()
app_1       |   File "/usr/lib/ckan/lib/python2.7/site-packages/paste/script/command.py", line 104, in run
app_1       |     invoke(command, command_name, options, args[1:])
app_1       |   File "/usr/lib/ckan/lib/python2.7/site-packages/paste/script/command.py", line 143, in invoke
app_1       |     exit_code = runner.run(args)
app_1       |   File "/usr/lib/ckan/lib/python2.7/site-packages/paste/script/command.py", line 238, in run
app_1       |     result = self.command()
app_1       |   File "/usr/lib/ckan/src/ckan/ckan/lib/cli.py", line 208, in command
app_1       |     self._load_config(cmd!='upgrade')
app_1       |   File "/usr/lib/ckan/src/ckan/ckan/lib/cli.py", line 148, in _load_config
app_1       |     load_environment(conf.global_conf, conf.local_conf)
app_1       |   File "/usr/lib/ckan/src/ckan/ckan/config/environment.py", line 232, in load_environment
app_1       |     p.load_all(config)
app_1       |   File "/usr/lib/ckan/src/ckan/ckan/plugins/core.py", line 138, in load_all
app_1       |     load(*plugins)
app_1       |   File "/usr/lib/ckan/src/ckan/ckan/plugins/core.py", line 170, in load
app_1       |     plugins_update()
app_1       |   File "/usr/lib/ckan/src/ckan/ckan/plugins/core.py", line 120, in plugins_update
app_1       |     environment.update_config()
app_1       |   File "/usr/lib/ckan/src/ckan/ckan/config/environment.py", line 283, in update_config
app_1       |     helpers = _Helpers(h)
app_1       |   File "/usr/lib/ckan/src/ckan/ckan/config/environment.py", line 42, in __init__
app_1       |     self._setup()
app_1       |   File "/usr/lib/ckan/src/ckan/ckan/config/environment.py", line 70, in _setup
app_1       |     raise Exception('overwritting extra helper %s' % helper)
app_1       | Exception: overwritting extra helper archiver_is_resource_broken_line
catalog-app_app_1 exited with code 1
```