### PR TITLE
Test for override helpers error in CKAN 2.3

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,18 +40,15 @@ jobs:
   build_ckan_23:
     working_directory: ~/ckanext-datagovtheme
     machine:
-      image: circleci/classic:201707-01
+      image: circleci/classic:201708-01
     environment:
       CKANVERSION=2.3
     steps:
       - checkout
       - run:
-          name: install
+          name: install_and_test
           command: bin/travis-build-CKAN-2.3.bash
-      - run:
-          name: test
-          command: bin/travis-run-tests-CKAN-2.3.sh
-
+      
 workflows:
   version: 2
   build_and_test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -31,9 +31,6 @@ jobs:
     steps:
       - checkout
       - run:
-          name: where am I
-          command: pwd && ls -la
-      - run:
           name: install
           command: bin/travis-build.bash
       - run:
@@ -49,14 +46,11 @@ jobs:
     steps:
       - checkout
       - run:
-          name: where am I
-          command: pwd && ls -la
-      - run:
           name: install
-          command: bin/travis-build.bash
+          command: bin/travis-build-CKAN-2.3.bash
       - run:
           name: test
-          command: bin/travis-run-tests.sh
+          command: bin/travis-run-tests-CKAN-2.3.sh
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,7 +40,7 @@ jobs:
   build_ckan_23:
     working_directory: ~/ckanext-datagovtheme
     machine:
-      image: circleci/classic:201708-01
+      image: circleci/classic:201707-01
     environment:
       CKANVERSION=2.3
     steps:

--- a/README.md
+++ b/README.md
@@ -51,3 +51,21 @@ To docker exec into the CKAN image, run:
 ### Run Tests with Docker
 
 ```docker-compose exec ckan /bin/bash -c "nosetests --ckan --with-pylons=src_extensions/datagovtheme/docker_test.ini src_extensions/datagovtheme/"```
+
+#### Test for CKAN 2.3 with catalog-app
+
+Get inside the container
+```
+docker-compose exec app bash
+```
+
+Run the tests
+```
+source /usr/lib/ckan/bin/activate
+cd /usr/lib/ckan/src/ckan
+cp ckan/public/base/css/main.css ckan/public/base/css/main.debug.css
+cd /usr/lib/ckan/src/ckanext-datagovtheme
+pip install -r dev-requirements.txt
+nosetests --ckan --with-pylons=test-catalog-2.3.ini ckanext.datagovtheme.tests.test_old_ckan
+```
+

--- a/README.md
+++ b/README.md
@@ -66,6 +66,6 @@ cd /usr/lib/ckan/src/ckan
 cp ckan/public/base/css/main.css ckan/public/base/css/main.debug.css
 cd /usr/lib/ckan/src/ckanext-datagovtheme
 pip install -r dev-requirements.txt
-nosetests --ckan --with-pylons=test-catalog-2.3.ini ckanext.datagovtheme.tests.test_old_ckan
+nosetests --ckan --with-pylons=test-catalog-2.3-local-catalog-app.ini ckanext.datagovtheme.tests.test_old_ckan
 ```
 

--- a/bin/travis-build-CKAN-2.3.bash
+++ b/bin/travis-build-CKAN-2.3.bash
@@ -2,16 +2,60 @@
 set -e
 
 echo "This is travis-build.bash..."
-
 echo "-----------------------------------------------------------------"
-echo "Installing the packages that CKAN requires..."
+
+echo "Moving to Python 2.7.10"
 sudo apt-get update -qq
-sudo apt-get install solr-jetty libcommons-fileupload-java libpq-dev postgresql postgresql-contrib swig libgeos-dev
+sudo apt-get install -y gcc-multilib g++-multilib libffi-dev libffi6 libffi6-dbg \
+    python-crypto python-mox3 python-pil python-ply libssl-dev zlib1g-dev libbz2-dev \
+    libexpat1-dev libbluetooth-dev libgdbm-dev dpkg-dev quilt autotools-dev \
+    libreadline-dev libtinfo-dev libncursesw5-dev tk-dev blt-dev libssl-dev zlib1g-dev \
+    libbz2-dev libexpat1-dev libbluetooth-dev libsqlite3-dev libgpm2 mime-support \
+    netbase net-tools bzip2 solr-jetty libcommons-fileupload-java libpq-dev \
+    postgresql postgresql-contrib swig libgeos-dev python-pastescript
+
+wget https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz
+tar xvf Python-2.7.10.tgz
+cd Python-2.7.10/
+
+./configure --prefix /usr/local/lib/python2.7.10 --enable-ipv6 --enable-unicode=ucs4
+make
+sudo make install
+
+sudo rm /usr/bin/python
+sudo ln -s /usr/local/lib/python2.7.10/bin/python /usr/bin/python
+export PATH="/usr/local/lib/python2.7.10/bin:$PATH"
+
+cd ..
+# -------------------
+echo 'Getting Python version:'
+python -V
+
+echo 'Getting Python path:'
+which python
+
+curl "https://bootstrap.pypa.io/get-pip.py" -o "get-pip.py"
+sudo python get-pip.py
+
+echo 'Preparing PIP ...'
+sudo -H python -m pip install --upgrade pip
+sudo -H python -m pip install setuptools -U
+sudo -H python -m pip install wheel
+
+echo "nosetests"
+sudo -H python -m pip install nose
+which nosetests
 
 echo "-----------------------------------------------------------------"
 echo "Installing CKAN and its dependencies..."
+# install all from catalog-app repo
+wget https://raw.githubusercontent.com/GSA/catalog-app/master/requirements-freeze.txt
+sed -i '/saml2/d' requirements-freeze.txt
+sudo -H python -m pip install -r requirements-freeze.txt
+sudo -H python -m pip install -U repoze.who==2.0 Paste==1.7.5.1
 
-cd .. # CircleCI starts inside ckanext-datajson folder
+echo "Cloning CKAN ..."
+cd .. # CircleCI starts inside ckanext-datagovtheme folder
 pwd
 ls -la
 
@@ -20,18 +64,10 @@ cd ckan
 git checkout datagov
 
 echo "-----------------------------------------------------------------"
-echo "Installing Python dependencies..."
+echo "Installing CKAN ..."
 
-pip install --upgrade pip
-pip install setuptools -U
-
-python setup.py develop
 # TODO remove after upgrading to CKAN 2.8
 cp ./ckan/public/base/css/main.css ./ckan/public/base/css/main.debug.css
-pip install wheel
-
-# install all from catalog-app repo
-pip install -r https://raw.githubusercontent.com/GSA/catalog-app/master/requirements-freeze.txt
 
 cd ..
 echo "-----------------------------------------------------------------"
@@ -48,29 +84,32 @@ echo "-----------------------------------------------------------------"
 echo "Creating the PostgreSQL user and database..."
 sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
 sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
-sudo -u postgres psql -c 'CREATE DATABASE datastore_test WITH OWNER ckan_default;'
 
 echo "-----------------------------------------------------------------"
 echo "Initialising the database..."
 cd ckan
-paster db init -c test-core.ini
+sudo paster --plugin=ckan db init -c test-core.ini
 echo "-----------------------------------------------------------------"
 echo "Initialising the report ..."
-paster --plugin=ckanext-report report initdb -c ../ckan/test-core.ini
+sudo paster --plugin=ckanext-report report initdb -c test-core.ini
 echo "-----------------------------------------------------------------"
 echo "Initialising the archiver ..."
-paster --plugin=ckanext-archiver archiver init -c ../ckan/test-core.ini
+sudo paster --plugin=ckanext-archiver archiver init -c test-core.ini
 echo "-----------------------------------------------------------------"
 echo "Initialising the harvester ..."
-paster --plugin=ckanext-harvest harvester initdb -c ../ckan/test-core.ini
+sudo paster --plugin=ckanext-harvest harvester initdb -c test-core.ini
 echo "-----------------------------------------------------------------"
 echo "Initialising the qa ..."
-paster --plugin=ckanext-qa qa init -c ../ckan/test-core.ini
+sudo paster --plugin=ckanext-qa qa init -c test-core.ini
 
 cd ..
 echo "-----------------------------------------------------------------"
 echo "Installing ckanext-datagovtheme and its requirements..."
 cd ckanext-datagovtheme
-python setup.py develop
+sudo python setup.py develop
 
 echo "travis-build.bash is done."
+
+echo "TESTING ckanext-datagovtheme with CKAN 2.3 and Bootstrap 2"
+sudo -H python -m pip install -r dev-requirements.txt
+nosetests --ckan --with-pylons=test-catalog-2.3.ini ckanext/datagovtheme/tests --nologcapture

--- a/bin/travis-build-CKAN-2.3.bash
+++ b/bin/travis-build-CKAN-2.3.bash
@@ -1,0 +1,128 @@
+#!/bin/bash
+set -e
+
+echo "This is travis-build.bash..."
+
+echo "-----------------------------------------------------------------"
+echo "Installing the packages that CKAN requires..."
+sudo apt-get update -qq
+sudo apt-get install solr-jetty libcommons-fileupload-java libpq-dev postgresql postgresql-contrib
+
+echo "-----------------------------------------------------------------"
+echo "Installing CKAN and its dependencies..."
+
+cd .. # CircleCI starts inside ckanext-datajson folder
+pwd
+ls -la
+
+git clone https://github.com/GSA/ckan
+cd ckan
+git checkout datagov
+
+echo "-----------------------------------------------------------------"
+echo "Installing Python dependencies..."
+
+pip install --upgrade pip
+pip install setuptools -U
+
+python setup.py develop
+# TODO remove after upgrading to CKAN 2.8
+cp ./ckan/public/base/css/main.css ./ckan/public/base/css/main.debug.css
+pip install wheel
+pip install -r requirements.txt
+pip install -r dev-requirements.txt
+
+cd ..
+echo "-----------------------------------------------------------------"
+echo "Setting up Solr..."
+# solr is multicore for tests on ckan master now, but it's easier to run tests
+# on Travis single-core still.
+# see https://github.com/ckan/ckan/issues/2972
+sed -i -e 's/solr_url.*/solr_url = http:\/\/127.0.0.1:8983\/solr/' ckan/test-core.ini
+printf "NO_START=0\nJETTY_HOST=127.0.0.1\nJETTY_PORT=8983\nJAVA_HOME=$JAVA_HOME" | sudo tee /etc/default/jetty
+sudo cp ckan/ckan/config/solr/schema.xml /etc/solr/conf/schema.xml
+sudo service jetty restart
+
+echo "-----------------------------------------------------------------"
+echo "Creating the PostgreSQL user and database..."
+sudo -u postgres psql -c "CREATE USER ckan_default WITH PASSWORD 'pass';"
+sudo -u postgres psql -c 'CREATE DATABASE ckan_test WITH OWNER ckan_default;'
+sudo -u postgres psql -c 'CREATE DATABASE datastore_test WITH OWNER ckan_default;'
+
+echo "-----------------------------------------------------------------"
+echo "Initialising the database..."
+cd ckan
+paster db init -c test-core.ini
+
+cd ..
+echo "-----------------------------------------------------------------"
+echo "Installing Report"
+git clone https://github.com/GSA/ckanext-report
+cd ckanext-report
+git checkout datagov
+
+python setup.py develop
+paster --plugin=ckanext-report report initdb -c ../ckan/test-core.ini
+
+cd ..
+echo "-----------------------------------------------------------------"
+echo "Installing Archiver"
+git clone https://github.com/GSA/ckanext-archiver
+cd ckanext-archiver
+git checkout datagov
+
+pip install -r requirements.txt
+python setup.py develop
+paster --plugin=ckanext-archiver archiver init -c ../ckan/test-core.ini
+
+cd ..
+echo "-----------------------------------------------------------------"
+echo "Installing Harvester"
+git clone https://github.com/ckan/ckanext-harvest
+cd ckanext-harvest
+git checkout master
+
+python setup.py develop
+pip install -r pip-requirements.txt
+
+paster harvester initdb -c ../ckan/test-core.ini
+
+cd ..
+echo "-----------------------------------------------------------------"
+echo "Installing Geodatagov"
+git clone https://github.com/GSA/ckanext-geodatagov
+cd ckanext-geodatagov
+git checkout master
+
+python setup.py develop
+pip install -r pip-requirements.txt
+
+cd ..
+echo "-----------------------------------------------------------------"
+echo "Installing Spatial"
+git clone https://github.com/ckan/ckanext-spatial
+cd ckanext-spatial
+git checkout master
+
+python setup.py develop
+pip install -r pip-requirements.txt
+
+cd ..
+echo "-----------------------------------------------------------------"
+echo "Installing QA"
+git clone https://github.com/GSA/ckanext-qa
+cd ckanext-qa
+git checkout datagov
+
+python setup.py develop
+pip install -r requirements.txt
+paster --plugin=ckanext-qa qa init -c ../ckan/test-core.ini
+
+cd ..
+echo "-----------------------------------------------------------------"
+echo "Installing ckanext-datagovtheme and its requirements..."
+cd ckanext-datagovtheme
+pip install -r dev-requirements.txt
+python setup.py develop
+
+echo "travis-build.bash is done."

--- a/bin/travis-build-CKAN-2.3.bash
+++ b/bin/travis-build-CKAN-2.3.bash
@@ -6,7 +6,7 @@ echo "This is travis-build.bash..."
 echo "-----------------------------------------------------------------"
 echo "Installing the packages that CKAN requires..."
 sudo apt-get update -qq
-sudo apt-get install solr-jetty libcommons-fileupload-java libpq-dev postgresql postgresql-contrib
+sudo apt-get install solr-jetty libcommons-fileupload-java libpq-dev postgresql postgresql-contrib swig libgeos-dev
 
 echo "-----------------------------------------------------------------"
 echo "Installing CKAN and its dependencies..."
@@ -29,8 +29,9 @@ python setup.py develop
 # TODO remove after upgrading to CKAN 2.8
 cp ./ckan/public/base/css/main.css ./ckan/public/base/css/main.debug.css
 pip install wheel
-pip install -r requirements.txt
-pip install -r dev-requirements.txt
+
+# install all from catalog-app repo
+pip install -r https://raw.githubusercontent.com/GSA/catalog-app/master/requirements-freeze.txt
 
 cd ..
 echo "-----------------------------------------------------------------"
@@ -53,76 +54,23 @@ echo "-----------------------------------------------------------------"
 echo "Initialising the database..."
 cd ckan
 paster db init -c test-core.ini
-
-cd ..
 echo "-----------------------------------------------------------------"
-echo "Installing Report"
-git clone https://github.com/GSA/ckanext-report
-cd ckanext-report
-git checkout datagov
-
-python setup.py develop
+echo "Initialising the report ..."
 paster --plugin=ckanext-report report initdb -c ../ckan/test-core.ini
-
-cd ..
 echo "-----------------------------------------------------------------"
-echo "Installing Archiver"
-git clone https://github.com/GSA/ckanext-archiver
-cd ckanext-archiver
-git checkout datagov
-
-pip install -r requirements.txt
-python setup.py develop
+echo "Initialising the archiver ..."
 paster --plugin=ckanext-archiver archiver init -c ../ckan/test-core.ini
-
-cd ..
 echo "-----------------------------------------------------------------"
-echo "Installing Harvester"
-git clone https://github.com/ckan/ckanext-harvest
-cd ckanext-harvest
-git checkout master
-
-python setup.py develop
-pip install -r pip-requirements.txt
-
-paster harvester initdb -c ../ckan/test-core.ini
-
-cd ..
+echo "Initialising the harvester ..."
+paster --plugin=ckanext-harvest harvester initdb -c ../ckan/test-core.ini
 echo "-----------------------------------------------------------------"
-echo "Installing Geodatagov"
-git clone https://github.com/GSA/ckanext-geodatagov
-cd ckanext-geodatagov
-git checkout master
-
-python setup.py develop
-pip install -r pip-requirements.txt
-
-cd ..
-echo "-----------------------------------------------------------------"
-echo "Installing Spatial"
-git clone https://github.com/ckan/ckanext-spatial
-cd ckanext-spatial
-git checkout master
-
-python setup.py develop
-pip install -r pip-requirements.txt
-
-cd ..
-echo "-----------------------------------------------------------------"
-echo "Installing QA"
-git clone https://github.com/GSA/ckanext-qa
-cd ckanext-qa
-git checkout datagov
-
-python setup.py develop
-pip install -r requirements.txt
+echo "Initialising the qa ..."
 paster --plugin=ckanext-qa qa init -c ../ckan/test-core.ini
 
 cd ..
 echo "-----------------------------------------------------------------"
 echo "Installing ckanext-datagovtheme and its requirements..."
 cd ckanext-datagovtheme
-pip install -r dev-requirements.txt
 python setup.py develop
 
 echo "travis-build.bash is done."

--- a/bin/travis-run-tests-CKAN-2.3.sh
+++ b/bin/travis-run-tests-CKAN-2.3.sh
@@ -1,6 +1,0 @@
-#!/bin/sh -e
-
-echo "TESTING ckanext-datagovtheme with CKAN 2.3 and Bootstrap 2"
-
-nosetests --ckan --with-pylons=test-catalog-2.3.ini ckanext/datagovtheme/tests --nologcapture
-

--- a/bin/travis-run-tests-CKAN-2.3.sh
+++ b/bin/travis-run-tests-CKAN-2.3.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -e
+
+echo "TESTING ckanext-datagovtheme with CKAN 2.3 and Bootstrap 2"
+
+nosetests --ckan --with-pylons=test-catalog-2.3.ini ckanext/datagovtheme/tests --nologcapture
+

--- a/ckanext/datagovtheme/tests/test_old_ckan.py
+++ b/ckanext/datagovtheme/tests/test_old_ckan.py
@@ -1,0 +1,19 @@
+import ckan.plugins as p
+
+
+def test_helpers_collition():
+    """ To fix helpers name collition in CKAN 2.3
+        https://github.com/GSA/ckanext-datagovtheme/pull/53
+    """
+
+    if not p.toolkit.check_ckan_version(max_version='2.3'):
+        return
+
+    extra_helpers = []
+    for plugin in p.PluginImplementations(p.ITemplateHelpers):
+        helpers = plugin.get_helpers()
+        for helper in helpers:
+            if helper in extra_helpers:
+                raise Exception('overwritting extra helper %s' % helper)
+            extra_helpers.append(helper)
+            

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,2 @@
+ckantoolkit
+mock

--- a/test-catalog-2.3-local-catalog-app.ini
+++ b/test-catalog-2.3-local-catalog-app.ini
@@ -1,0 +1,48 @@
+[DEFAULT]
+debug = true
+# Uncomment and replace with the address which should receive any error reports
+#email_to = you@yourdomain.com
+smtp_server = localhost
+error_email_from = paste@localhost
+
+[app:main]
+use = config:../ckan/test-core.ini
+ckan.site_title = My Test CKAN Site
+ckan.site_description = A test site for testing my CKAN extension
+ckan.plugins = stats geodatagov datagov_harvest ckan_harvester geodatagov_geoportal_harvester z3950_harvester arcgis_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester geodatagov_miscs spatial_metadata spatial_query resource_proxy spatial_harvest_metadata_api datagovtheme datajson_harvest archiver report qa
+ckan.legacy_templates = no
+sqlalchemy.url = postgresql://ckan:pass@db/ckan
+solr_url = http://solr:8983/solr/ckan
+
+# Logging configuration
+[loggers]
+keys = root, ckan, sqlalchemy
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_ckan]
+qualname = ckan
+handlers = 
+level = INFO
+
+[logger_sqlalchemy]
+handlers =
+qualname = sqlalchemy.engine
+level = WARN  
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/test-catalog-2.3.ini
+++ b/test-catalog-2.3.ini
@@ -1,0 +1,46 @@
+[DEFAULT]
+debug = true
+# Uncomment and replace with the address which should receive any error reports
+#email_to = you@yourdomain.com
+smtp_server = localhost
+error_email_from = paste@localhost
+
+[app:main]
+use = config:../ckan/test-core.ini
+ckan.site_title = My Test CKAN Site
+ckan.site_description = A test site for testing my CKAN extension
+ckan.plugins = stats geodatagov datagov_harvest ckan_harvester geodatagov_geoportal_harvester z3950_harvester arcgis_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester geodatagov_miscs spatial_metadata spatial_query resource_proxy spatial_harvest_metadata_api datagovtheme archiver report qa
+ckan.legacy_templates = no
+
+# Logging configuration
+[loggers]
+keys = root, ckan, sqlalchemy
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARN
+handlers = console
+
+[logger_ckan]
+qualname = ckan
+handlers = 
+level = INFO
+
+[logger_sqlalchemy]
+handlers =
+qualname = sqlalchemy.engine
+level = WARN  
+
+[handler_console]
+class = StreamHandler
+args = (sys.stdout,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(asctime)s %(levelname)-5.5s [%(name)s] %(message)s

--- a/test-catalog-2.3.ini
+++ b/test-catalog-2.3.ini
@@ -1,5 +1,5 @@
 [DEFAULT]
-debug = true
+debug = false
 # Uncomment and replace with the address which should receive any error reports
 #email_to = you@yourdomain.com
 smtp_server = localhost
@@ -9,7 +9,7 @@ error_email_from = paste@localhost
 use = config:../ckan/test-core.ini
 ckan.site_title = My Test CKAN Site
 ckan.site_description = A test site for testing my CKAN extension
-ckan.plugins = stats geodatagov datagov_harvest ckan_harvester geodatagov_geoportal_harvester z3950_harvester arcgis_harvester waf_harvester_collection geodatagov_csw_harvester geodatagov_doc_harvester geodatagov_waf_harvester geodatagov_miscs spatial_metadata spatial_query resource_proxy spatial_harvest_metadata_api datagovtheme archiver report qa
+ckan.plugins = stats datagov_harvest ckan_harvester resource_proxy datagovtheme archiver report qa
 ckan.legacy_templates = no
 
 # Logging configuration


### PR DESCRIPTION
Test for [hotfix recently created](https://github.com/GSA/ckanext-datagovtheme/pull/53)

Ensure we are not duplicating helper names for CKAN 2.3

## Notes
Most changes related to the need for Python 2.7.10 (2.7.11 will fail). By adding more extension to the environment to test this _helpers collition_
`ckanext-archiver` and `ckanext-qa` uses an old celery version, which uses an old kombu version, which depends on python 2.7.10 (>=2.7.11 will fail)