### PR TITLE
Redirect to filtered harvest sources list

### DIFF
--- a/ckanext/datagovtheme/templates/organization/edit_base.html
+++ b/ckanext/datagovtheme/templates/organization/edit_base.html
@@ -10,7 +10,7 @@
 
 {% block content_primary_nav %}
   {{ super() }}
-  {% set url = h.url_for('harvest_org_list', id=c.group_dict.name) %}
+  {% set url = h.url_for('/harvest', organization=organization.name) %}
   <li class="{{ 'active' if c.action == 'source_list' }}">
   	<a href="{{ url }}">
   		<i class="icon-refresh"></i>


### PR DESCRIPTION
Related to [GSA#321](https://github.com/GSA/datagov-ckan-multi/issues/321)
A [different approach](https://github.com/GSA/datagov-ckan-multi/issues/321#issuecomment-666353696) to simply get the sources list from an organization.
 
![image](https://user-images.githubusercontent.com/3237309/92410450-7ace3700-f11a-11ea-9d6d-47993af2176a.png)
