### PR TITLE
Fix URL to API docs

### DIFF
--- a/ckanext/datagovtheme/templates/package/search.html
+++ b/ckanext/datagovtheme/templates/package/search.html
@@ -99,7 +99,7 @@
         <p>
             <small>
                 {% set api_link = h.link_to(_('API'), h.url_for(controller='api', action='get_api', ver=3)) %}
-                {% set api_doc_link = h.link_to(_('API Docs'), 'http://docs.ckan.org/{0}/ckan-2.3.5/api/'.format(request.environ.CKAN_LANG)) %}
+                {% set api_doc_link = h.link_to(_('API Docs'), 'https://docs.ckan.org/{0}/2.8/api/index.html'.format(request.environ.CKAN_LANG)) %}
                 {% if g.dumps_url -%}
                 {% set dump_link = h.link_to(_('full {format} dump').format(format=g.dumps_format), g.dumps_url) %}
                 {% trans %}


### PR DESCRIPTION
Related to [Multi#444](https://github.com/GSA/datagov-ckan-multi/issues/444)

This PR just update the URL to new API documentation