### PR TITLE
Updated test ini localtion at catalog-next repo

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,7 @@ jobs:
           command: |
             docker-compose logs db
             docker-compose logs ckan
-            docker-compose exec ckan /bin/bash -c "cd src/ckan/ && wget https://raw.githubusercontent.com/GSA/catalog.data.gov/master/tools/ci-scripts/test-catalog-next.ini && nosetests --ckan --with-pylons=test-catalog-next.ini ../../src_extensions/datagovtheme/"
+            docker-compose exec ckan /bin/bash -c "nosetests --ckan --with-pylons=src/ckan/test-catalog-next.ini src_extensions/datagovtheme/"
   build_ckan_28:
     working_directory: ~/ckanext-datagovtheme
     machine:

--- a/README.md
+++ b/README.md
@@ -53,8 +53,7 @@ To docker exec into the CKAN image, run:
 Test using full environment from [catalog-next](https://github.com/GSA/catalog.data.gov) (CKAN 2.8) repo
 
 ```
-docker-compose exec ckan /bin/bash -c "cd src/ckan/ && \
-    wget https://raw.githubusercontent.com/GSA/catalog.data.gov/master/tools/ci-scripts/test-catalog-next.ini && \ nosetests --ckan --with-pylons=test-catalog-next.ini ../../src_extensions/datagovtheme/"
+docker-compose exec ckan /bin/bash -c "nosetests --ckan --with-pylons=src/ckan/test-catalog-next.ini src_extensions/datagovtheme/"
 ```
 
 #### Test for CKAN 2.3 with catalog-app

--- a/bin/travis-build-2.8.bash
+++ b/bin/travis-build-2.8.bash
@@ -4,7 +4,7 @@ set -e
 echo "Updating script ..."
 
 wget https://raw.githubusercontent.com/GSA/catalog.data.gov/master/tools/ci-scripts/circleci-build-catalog-next.bash
-wget https://raw.githubusercontent.com/GSA/catalog.data.gov/master/tools/ci-scripts/test-catalog-next.ini
+wget https://raw.githubusercontent.com/GSA/catalog.data.gov/master/ckan/test-catalog-next.ini
 
 sudo chmod +x circleci-build-catalog-next.bash
 source circleci-build-catalog-next.bash


### PR DESCRIPTION
Related to [this PR](https://github.com/GSA/catalog.data.gov/pull/156)

Test ini file at catalog.data.gov repo was relocated, so we need to update tests at extensions

Note: this PR will fail until the related PRis merged