### PR TITLE
Fix RDF URL

### DIFF
--- a/ckanext/datagovtheme/templates/package/read_base.html
+++ b/ckanext/datagovtheme/templates/package/read_base.html
@@ -4,7 +4,7 @@
 
 {% block links -%}
 {{ super() }}
-<link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(controller='package', action='read', id=pkg.id, format='rdf', qualified=True) }}"/>
+<link rel="alternate" type="application/rdf+xml" href="{{ h.url_for(controller='ckanext.dcat.controllers:DCATController', action='read_dataset', _id=pkg.id, _format='rdf', qualified=True) }}"/>
 {% endblock -%}
 
 


### PR DESCRIPTION
Related to [Multi#445](https://github.com/GSA/datagov-ckan-multi/issues/445)

This PR:
 - Fixes internal RDF URL to fit the DCAT extension format