### PR TITLE
Revert "Use new ckan function for showing package "notes""

### DIFF
--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -33,12 +33,15 @@
     {% endif %}
     <br clear="all" />
 		
-	  {% block package_notes %}
-      <div itemprop="description" class="notes embedded-content">
-          {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
+	{# <h4> {{ pkg }}</h4> #}
+    {% block package_notes %}
+      {% if c.pkg_notes_formatted %}
+        <div itemprop="description" class="notes embedded-content">
+          {{ c.pkg_notes_formatted }}
         </div>
+      {% endif %}
     {% endblock %}
-  
+    {# FIXME why is this here? seems wrong #}
     <span class="insert-comment-thread"></span>
 </section>
 {% endblock %}


### PR DESCRIPTION
Reverts GSA/ckanext-datagovtheme#47 due to https://github.com/GSA/datagov-deploy/issues/2515