### PR TITLE
Fix notes for CKAN 2.3 and 2.8

### DIFF
--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -35,11 +35,16 @@
 		
 	{# <h4> {{ pkg }}</h4> #}
     {% block package_notes %}
-      {% if c.pkg_notes_formatted %}
-        <div itemprop="description" class="notes embedded-content">
-          {{ c.pkg_notes_formatted }}
-        </div>
+
+      <div itemprop="description" class="notes embedded-content">
+      {% if h.is_bootstrap2 %} 
+          {% if c.pkg_notes_formatted %}
+              {{ c.pkg_notes_formatted }}
+          {% endif %}
+      {% else %}
+          {{ h.render_markdown(h.get_translated(pkg, 'notes')) }}
       {% endif %}
+      </div>
     {% endblock %}
     {# FIXME why is this here? seems wrong #}
     <span class="insert-comment-thread"></span>

--- a/ckanext/datagovtheme/tests/test_datagovtheme.py
+++ b/ckanext/datagovtheme/tests/test_datagovtheme.py
@@ -3,7 +3,7 @@
 '''Tests for the ckanext.datagovtheme extension.
 
 '''
-from nose.tools import assert_in, assert_true, assert_not_in, assert_false
+from nose.tools import assert_in, assert_true, assert_not_in
 
 try:
     from ckan.tests.helpers import FunctionalTestBase
@@ -16,26 +16,6 @@ import ckanext
 
 class TestDatagovthemeServed(FunctionalTestBase):
     '''Tests for the ckanext.datagovtheme.plugin module.'''
-
-    @classmethod
-    def setup_class(cls):
-        super(TestDatagovthemeServed, cls).setup_class()
-
-        if not p.plugin_loaded('geodatagov'):
-            p.load('geodatagov')
-
-        if not p.plugin_loaded('datagovtheme'):
-            p.load('datagovtheme')
-
-    @classmethod
-    def teardown_class(cls):
-        super(TestDatagovthemeServed, cls).teardown_class()
-        p.unload('geodatagov')
-        p.unload('datagovtheme')
-
-    def test_plugin_loaded(self):
-        assert_true(p.plugin_loaded('datagovtheme'))
-        assert_true(p.plugin_loaded('geodatagov'))
 
     def test_datagovtheme_css_file(self):
         app = self._get_test_app()

--- a/ckanext/datagovtheme/tests/test_notes.py
+++ b/ckanext/datagovtheme/tests/test_notes.py
@@ -1,0 +1,24 @@
+# encoding: utf-8
+from nose.tools import assert_in, assert_true, assert_not_in, assert_false
+
+try:
+    from ckan.tests.helpers import FunctionalTestBase, reset_db
+    from ckan.tests import factories
+except ImportError:
+    from ckan.new_tests.helpers import FunctionalTestBase, reset_db
+    from ckan.new_tests import factories
+
+
+class TestNotes(FunctionalTestBase):
+    '''Tests for the ckanext.datagovtheme.plugin module.'''
+
+    def test_datagovtheme_html_loads(self):
+
+        notes = 'Notes for a test dataset'
+        dataset = factories.Dataset(notes=notes)
+        app = self._get_test_app()
+
+        dataset_response = app.get('/dataset/{}'.format(dataset['name']))
+    
+        assert_in('<div itemprop="description" class="notes embedded-content">', dataset_response.unicode_body)
+        assert_in('notes', dataset_response.unicode_body)

--- a/ckanext/datagovtheme/tests/test_notes.py
+++ b/ckanext/datagovtheme/tests/test_notes.py
@@ -1,11 +1,11 @@
 # encoding: utf-8
-from nose.tools import assert_in, assert_true, assert_not_in, assert_false
+from nose.tools import assert_in
 
 try:
-    from ckan.tests.helpers import FunctionalTestBase, reset_db
+    from ckan.tests.helpers import FunctionalTestBase
     from ckan.tests import factories
 except ImportError:
-    from ckan.new_tests.helpers import FunctionalTestBase, reset_db
+    from ckan.new_tests.helpers import FunctionalTestBase
     from ckan.new_tests import factories
 
 

--- a/ckanext/datagovtheme/tests/test_ui_data.py
+++ b/ckanext/datagovtheme/tests/test_ui_data.py
@@ -1,20 +1,17 @@
 from bs4 import BeautifulSoup
 import logging
-import json
 from nose.tools import assert_equal, assert_in
 import urllib2
-from ckan import plugins as p
+
 try:
-    from ckan.tests.helpers import reset_db, FunctionalTestBase
+    from ckan.plugins.toolkit import config
+    from ckan.tests.helpers import FunctionalTestBase
     from ckan.tests import factories
 except ImportError:
-    from ckan.new_tests.helpers import reset_db, FunctionalTestBase
+    from pylons import config
+    from ckan.new_tests.helpers import FunctionalTestBase
     from ckan.new_tests import factories
 
-if p.toolkit.check_ckan_version(max_version='2.3'):
-    from pylons import config
-else:
-    from ckan.plugins.toolkit import config
 
 log = logging.getLogger(__name__)
 

--- a/ckanext/datagovtheme/tests/test_ui_data.py
+++ b/ckanext/datagovtheme/tests/test_ui_data.py
@@ -21,11 +21,6 @@ log = logging.getLogger(__name__)
 
 class TestUIData(FunctionalTestBase):
 
-    @classmethod
-    def setup(cls):
-        super(TestUIData, cls).setup_class()
-        reset_db()
-        
     def create_datasets(self):
         organization = factories.Organization()
         self.group1 = factories.Group()


### PR DESCRIPTION
Related to [Deploy#2515](https://github.com/GSA/datagov-deploy/issues/2515)

This PR:
 - Allow package's _notes_ from different CKAN version
 - Add test to both environments

### Notes

[This is](https://github.com/GSA/ckanext-datagovtheme/pull/75/commits/30aa3a321cba01b7d20daaaa21eaced1ed94f36f) the important change. Other commits are just for clean tests code