### PR TITLE
UI tweaks for dataset result page

### DIFF
--- a/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
@@ -2093,6 +2093,7 @@ margin-top: 0px;
 }
 .btn.btn-navbar{
     margin-top:15px;
+    float: right;
 }
 .module-heading .action {
     float: right;
@@ -2128,6 +2129,12 @@ margin-top: 0px;
 }
 
 @media screen and (max-width: 768px) {
+    #content {
+        padding: 0px;
+    }
+    .navbar-nav{
+        margin: auto;
+    }
     .container, .navbar-static-top .container, .navbar-fixed-top .container, .navbar-fixed-bottom .container {
     width:100%;
     }
@@ -2151,7 +2158,7 @@ margin-top: 0px;
         display: inline-block;
     }
     .masthead .container {
-    padding:0px;
+        padding-bottom: 15px;
     }
     [role="main"] .primary {
         width:100%;
@@ -2205,7 +2212,7 @@ margin-top: 0px;
     .search-giant button {
         position: absolute;
         right: 4%;
-        top: 18%;
+        top: 15%;
 
     }
     .page-header_new .toolbar{
@@ -2221,6 +2228,12 @@ margin-top: 0px;
     }
     #dataset-search .control-order-by {
         margin-left: 0px;
+        margin-top: 0px
+    }
+    #dataset-search .control-order-by label{
+        padding-top: 15px;
+        padding-bottom: 15px;
+        margin-bottom: 0px;
     }
     .search-form .control-order-by {
         margin-left: 0px;
@@ -2228,6 +2241,7 @@ margin-top: 0px;
     .toolbar{
         border-right:0px;
         border-left:0px;
+        padding: 15px;
     }
     .page_primary_action {
         margin-top:0px;

--- a/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
@@ -2200,7 +2200,7 @@ margin-top: 0px;
         float: none;
     }
     .control-order-by {
-        bottom: 0;
+        margin-bottom: 15px;
         float: left;
         position: relative;
     }

--- a/ckanext/datagovtheme/templates/package/search.html
+++ b/ckanext/datagovtheme/templates/package/search.html
@@ -61,7 +61,7 @@
             {% endif %}
         </div>
     </form></div>
-<a class="show-filters btn">{{ _('Filter Results') }}</a>
+<a class="show-filters btn btn-primary">{{ _('Filter Results') }}</a>
 {% endblock %}
 
 {% block primary_content %}


### PR DESCRIPTION
Related issue:
https://github.com/GSA/datagov-deploy/issues/2465

- Menu aligned to the right of the page
- 15px gutter is uniformly applied across all elements
- Apply gutter when menu is expanded
- "Order By" label has more margin above
- "Filter datasets" is converted primary button
- Dataset results content is edge to edge

### Screenshots:
![image](https://user-images.githubusercontent.com/3371013/105869164-61b61c00-6010-11eb-9c2c-b06a5ae879b7.png)
![image](https://user-images.githubusercontent.com/3371013/105869868-2536f000-6011-11eb-9e52-8a3a9e795199.png)

