### PR TITLE
Add check to see if maintainer email exists before using .strip() method

### DIFF
--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -333,7 +333,7 @@
             <td>
               <div itemprop="provider" itemscope itemtype="http://schema.org/Person">
 
-              {% if pkg_dict.maintainer_email.strip()|length > 0 %}
+              {% if pkg_dict.maintainer_email and pkg_dict.maintainer_email.strip()|length > 0 %}
                 {% if is_bootstrap2 %} {# preserve compatibility with old CKAN versions #}
                   {% set a_mail = h.mail_to(email_address=pkg_dict.maintainer_email) %}
                 {% else %}


### PR DESCRIPTION
https://github.com/gsa/datagov-ckan-multi/issues/559