### PR TITLE
Update links for admin pages

### DIFF
--- a/ckanext/datagovtheme/templates/header-site-usage.html
+++ b/ckanext/datagovtheme/templates/header-site-usage.html
@@ -35,13 +35,6 @@
                 {% if c.userobj %}
                 <nav class="account avatar authed" data-module="me" data-me="{{ c.userobj.id }}">
                     <ul class="unstyled">
-                        {% if c.userobj.sysadmin %}
-                        <li>
-                            <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
-                                <i class="icon-legal"></i>
-                            </a>
-                        </li>
-                        {% endif %}
                         <li>
                             <a href="{{ h.url_for(controller='user', action='read', id=c.userobj.name) }}" class="image" title="{{ _('View profile') }}">
                                 {{ h.gravatar((c.userobj.email_hash if c and c.userobj else ''), size=16) }}
@@ -55,11 +48,13 @@
                                 <span>{{ new_activities }}</span>
                             </a>
                         </li>
+                        {% if c.userobj.sysadmin %}
                         <li>
-                            <a href="{{ h.saml2_user_edit_url() }}" title="{{ _('Edit settings') }}">
-                                <i class="icon-cog"></i>
+                            <a href="{{ h.url_for(controller='admin', action='index') }}" title="{{ _('Sysadmin settings') }}">
+                                <i class="icon-legal"></i>
                             </a>
                         </li>
+                        {% endif %}
                         <li>
                             <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
                                 <i class="icon-signout"></i>

--- a/ckanext/datagovtheme/templates/header.html
+++ b/ckanext/datagovtheme/templates/header.html
@@ -34,14 +34,6 @@
                 {% if c.userobj %}
                 <nav class="account avatar authed" data-module="me" data-me="{{ c.userobj.id }}">
                     <ul class="unstyled">
-                        {% if c.userobj.sysadmin %}
-                        <li>
-                            <a href="{{ h.url_for(controller='admin', action='index') }}"
-                                title="{{ _('Sysadmin settings') }}">
-                                <i class="fa fa-gavel" aria-hidden="true"></i>
-                            </a>
-                        </li>
-                        {% endif %}
                         <li>
                             <a href="{{ h.url_for(controller='user', action='read', id=c.userobj.name) }}" class="image" title="{{ _('View profile') }}">
                                 {% if is_bootstrap2 %}
@@ -72,11 +64,14 @@
                             </a>
                         </li>
                         {% endif %}
+                        {% if c.userobj.sysadmin %}
                         <li>
-                            <a href="{{ h.saml2_user_edit_url() }}" title="{{ _('Edit settings') }}">
-                                <i class="fa fa-cog" aria-hidden="true"></i>
+                            <a href="{{ h.url_for(controller='admin', action='index') }}"
+                                title="{{ _('Sysadmin settings') }}">
+                                <i class="fa fa-gavel" aria-hidden="true"></i>
                             </a>
                         </li>
+                        {% endif %}
                         <li>
                             <a href="{{ h.url_for('/user/_logout') }}" title="{{ _('Log out') }}">
                                 <i class="fa fa-sign-out" aria-hidden="true"></i>


### PR DESCRIPTION
Related to https://github.com/GSA/datagov-deploy/issues/2850.
New dashboard header (links work as expected): 
![image](https://user-images.githubusercontent.com/26980513/109718322-6799a280-7b64-11eb-9585-6b74575cd958.png)
