### PR TITLE
Parse bureau code file as unicode

### DIFF
--- a/.github/workflows/ckan.yml
+++ b/.github/workflows/ckan.yml
@@ -3,7 +3,7 @@
 name: Tests
 on: [pull_request]
 env:
-  CODE_COVERAGE_THRESHOLD_REQUIRED: 28
+  CODE_COVERAGE_THRESHOLD_REQUIRED: 33
 
 jobs:
   lint:

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -805,7 +805,7 @@ def get_bureau_info(bureau_code):
 
     csv_content = io.BytesIO(file_content)
     if sys.version_info >= (3, 0):
-        csv_content = io.StringIO(file_content)
+        csv_content = io.StringIO(file_content.decode('utf-8'))
     for row in csv.reader(csv_content):
         if agency == row[2].zfill(3) \
                 and bureau == row[3].zfill(2):

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -786,6 +786,8 @@ def get_bureau_info(bureau_code):
         else:
             file_obj = open(filename, 'w+')
             file_content = resource.read()
+            if isinstance(file_content, bytes):
+                file_content = file_content.decode('utf-8')
             file_obj.write(file_content)
 
     file_obj.close()

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -800,10 +800,10 @@ def get_bureau_info(bureau_code):
         return None
 
     # Translate to unicode if value is a string
-    if isinstance(file_content, str):
-        file_content = unicode(file_content, "utf-8")
+    # if isinstance(file_content, str):
+    #     file_content = unicode(file_content, "utf-8")
     
-    for row in csv.reader(io.StringIO(file_content)):
+    for row in csv.reader(io.BytesIO(file_content)):
         if agency == row[2].zfill(3) \
                 and bureau == row[3].zfill(2):
             bureau_info['title'] = row[1]

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -767,7 +767,7 @@ def get_bureau_info(bureau_code):
     # check to see if file is older than .5 hour
     if (time_current - time_file) < old_div(3600, 2):
         file_obj = open(filename)
-        file_conent = file_obj.read()
+        file_content = file_obj.read()
     else:
         # it means file is old, or does not exist
         # fetch new content
@@ -780,13 +780,13 @@ def get_bureau_info(bureau_code):
             resource = urllib.request.urlopen(url, timeout=sec_timeout)
         except Exception:
             file_obj = open(filename)
-            file_conent = file_obj.read()
+            file_content = file_obj.read()
             # touch the file, so that it wont keep re-trying and slow down page loading
             os.utime(filename, None)
         else:
             file_obj = open(filename, 'w+')
-            file_conent = resource.read()
-            file_obj.write(file_conent)
+            file_content = resource.read()
+            file_obj.write(file_content)
 
     file_obj.close()
 
@@ -799,7 +799,11 @@ def get_bureau_info(bureau_code):
     except ValueError:
         return None
 
-    for row in csv.reader(io.StringIO(file_conent)):
+    # Translate to unicode if value is a string
+    if isinstance(file_content, str):
+        file_content = unicode(file_content, "utf-8")
+    
+    for row in csv.reader(io.StringIO(file_content)):
         if agency == row[2].zfill(3) \
                 and bureau == row[3].zfill(2):
             bureau_info['title'] = row[1]

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -787,6 +787,7 @@ def get_bureau_info(bureau_code):
         else:
             file_obj = open(filename, 'w+')
             file_content = resource.read()
+            # Handle differences between py2 and py3. Should use else statement for py3.
             if isinstance(file_content, bytes):
                 file_obj.write(file_content.decode('utf-8'))
             else:
@@ -803,6 +804,7 @@ def get_bureau_info(bureau_code):
     except ValueError:
         return None
 
+    # sent to csv as byte if python 2, else parse as string
     csv_content = io.BytesIO(file_content)
     if sys.version_info >= (3, 0):
         csv_content = io.StringIO(file_content.decode('utf-8'))

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -787,8 +787,9 @@ def get_bureau_info(bureau_code):
             file_obj = open(filename, 'w+')
             file_content = resource.read()
             if isinstance(file_content, bytes):
-                file_content = file_content.decode('utf-8')
-            file_obj.write(file_content)
+                file_obj.write(file_content.decode('utf-8'))
+            else:
+                file_obj.write(file_content)
 
     file_obj.close()
 

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -14,6 +14,7 @@ import re
 import time
 import urllib.parse
 import urllib.request
+import sys
 
 import pkg_resources
 
@@ -802,7 +803,10 @@ def get_bureau_info(bureau_code):
     except ValueError:
         return None
 
-    for row in csv.reader(io.StringIO(file_content)):
+    csv_content = io.BytesIO(file_content)
+    if sys.version_info >= (3, 0):
+        csv_content = io.StringIO(file_content)
+    for row in csv.reader(csv_content):
         if agency == row[2].zfill(3) \
                 and bureau == row[3].zfill(2):
             bureau_info['title'] = row[1]

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -802,7 +802,7 @@ def get_bureau_info(bureau_code):
     # Translate to unicode if value is a string
     # if isinstance(file_content, str):
     #     file_content = unicode(file_content, "utf-8")
-    
+
     for row in csv.reader(io.BytesIO(file_content)):
         if agency == row[2].zfill(3) \
                 and bureau == row[3].zfill(2):

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -802,11 +802,7 @@ def get_bureau_info(bureau_code):
     except ValueError:
         return None
 
-    # Translate to unicode if value is a string
-    # if isinstance(file_content, str):
-    #     file_content = unicode(file_content, "utf-8")
-
-    for row in csv.reader(io.BytesIO(file_content)):
+    for row in csv.reader(io.StringIO(file_content)):
         if agency == row[2].zfill(3) \
                 and bureau == row[3].zfill(2):
             bureau_info['title'] = row[1]

--- a/ckanext/datagovtheme/tests/test_helpers.py
+++ b/ckanext/datagovtheme/tests/test_helpers.py
@@ -41,4 +41,4 @@ class TestBureauCodeTransform(object):
 
         bureau_info = helpers.get_bureau_info("010:04")
 
-        assert bureau_info.title == "Bureau of Land Management"
+        assert bureau_info['title'] == "Bureau of Land Management"

--- a/ckanext/datagovtheme/tests/test_helpers.py
+++ b/ckanext/datagovtheme/tests/test_helpers.py
@@ -32,3 +32,13 @@ class TestApiDocUrl(object):
         api_doc_url = helpers.api_doc_url()
 
         assert 'https://docs.ckan.org/en/2.8/api/index.html' == api_doc_url
+
+
+class TestBureauCodeTransform(object):
+
+    @mock.patch('ckanext.datagovtheme.helpers.h')
+    def test_get_bureau_info(self, mock_ckan_lib_helpers):
+
+        bureau_info = helpers.get_bureau_info("010:04")
+
+        assert bureau_info.title == "Bureau of Land Management"

--- a/test.ini
+++ b/test.ini
@@ -15,6 +15,7 @@ ckan.plugins = datagovtheme
 ckan.legacy_templates = no
 sqlalchemy.url = postgresql://ckan:pass@db/ckan
 solr_url = http://solr:8983/solr/ckan
+ckanext.geodatagov.bureau_csv.url_default = https://resources.data.gov/schemas/dcat-us/v1.1/omb_bureau_codes.csv
 
 # Logging configuration
 [loggers]


### PR DESCRIPTION
Contents are not being parsed correctly, and the bureau code file is not being read correctly.
Unfortunately, csv parser for in-memory streams is [fundamentally different between python 2 and python 3](https://stackoverflow.com/questions/13120127/how-can-i-use-io-stringio-with-the-csv-module). I don't love this fix, but seems like the best path forward.