### PR TITLE
Update for flask parameter type

### DIFF
--- a/ckanext/datagovtheme/templates/templates_new/organization/read_base.html
+++ b/ckanext/datagovtheme/templates/templates_new/organization/read_base.html
@@ -32,7 +32,7 @@
 {% endblock %}
 
 {% block secondary_content %}
-  {% snippet 'snippets/organization.html', organization=c.group_dict, show_nums=true, bureau_codes=request.params.getall('bureauCode') %}
+  {% snippet 'snippets/organization.html', organization=c.group_dict, show_nums=true, bureau_codes=request.args.getall('bureauCode') %}
 
   {% block organization_facets %}{% endblock %}
 {% endblock %}


### PR DESCRIPTION
Flask uses args, not params.
The code was searched, and there are no other "similar" issues.