### PR TITLE
fix organization/group template

### DIFF
--- a/ckanext/datagovtheme/templates/templates_new/group/read.html
+++ b/ckanext/datagovtheme/templates/templates_new/group/read.html
@@ -1,15 +1,15 @@
 {% extends "group/read_base.html" %}
 
-{% block subtitle %}{{ c.group_dict.display_name }}{% endblock %}
+{% block subtitle %}{{ group_dict.display_name }}{% endblock %}
 
 {% block primary_content_inner %}
     {% block groups_search_form %}
     {% set facets = {
-    'fields': c.fields_grouped,
-    'search': c.search_facets,
-    'titles': c.facet_titles,
-    'translated_fields': c.translated_fields,
-    'remove_field': c.remove_field }
+    'fields': fields_grouped,
+    'search': search_facets,
+    'titles': facet_titles,
+    'translated_fields': translated_fields,
+    'remove_field': remove_field }
     %}
     {% set sorting = [
     (_('Relevance'), 'score desc, metadata_modified desc'),
@@ -18,15 +18,15 @@
     (_('Last Modified'), 'metadata_modified desc'),
     (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
     %}
-    {% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=c.fields %}
+    {% snippet 'snippets/search_form.html', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=fields %}
     {% endblock %}
     {% block packages_list %}
-        {% if c.page.items %}
-        {{ h.snippet('snippets/package_list.html', packages=c.page.items) }}
+        {% if page.items %}
+        {{ h.snippet('snippets/package_list.html', packages=page.items) }}
         {% endif %}
     {% endblock %}
     {% block page_pagination %}
-        {{ c.page.pager(q=c.q) }}
+        {{ page.pager(q=q) }}
     {% endblock %}
 {% endblock %}
 
@@ -34,8 +34,8 @@
     {{ super() }}
     <div class="filters">
         <div>
-        {% for facet in c.facet_titles %}
-        {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+        {% for facet in facet_titles %}
+        {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}) }}
         {% endfor %}
         </div>
         <a class="close no-text hide-filters"><i class="icon-remove-sign"></i><span class="text">close</span></a>

--- a/ckanext/datagovtheme/templates/templates_new/organization/read.html
+++ b/ckanext/datagovtheme/templates/templates_new/organization/read.html
@@ -1,19 +1,19 @@
 {% extends "organization/read_base.html" %}
 
 {% block page_primary_action %}
-{% if h.check_access('package_create', {'owner_org': c.group_dict.id}) %}
-{% link_for _('Add Dataset'), controller='dataset', action='new', group=c.group_dict.id, class_='btn btn-primary', icon='plus-sign-alt' %}
+{% if h.check_access('package_create', {'owner_org': group_dict.id}) %}
+{% link_for _('Add Dataset'), controller='dataset', action='new', group=group_dict.id, class_='btn btn-primary', icon='plus-sign-alt' %}
 {% endif %}
 {% endblock %}
 
 {% block primary_content_inner %}
 {% block groups_search_form %}
 {% set facets = {
-'fields': c.fields_grouped,
-'search': c.search_facets,
-'titles': c.facet_titles,
-'translated_fields': c.translated_fields,
-'remove_field': c.remove_field }
+'fields': fields_grouped,
+'search': search_facets,
+'titles': facet_titles,
+'translated_fields': translated_fields,
+'remove_field': remove_field }
 %}
 {% set sorting = [
 (_('Relevance'), 'score desc, metadata_modified desc'),
@@ -22,23 +22,23 @@
 (_('Last Modified'), 'metadata_modified desc'),
 (_('Popular'), 'views_recent desc') if g.tracking_enabled else (false, false) ]
 %}
-{% snippet 'snippets/search_form.html', type='dataset', query=c.q, sorting=sorting, sorting_selected=c.sort_by_selected, count=c.page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=c.fields %}
+{% snippet 'snippets/search_form.html', type='dataset', query=q, sorting=sorting, sorting_selected=sort_by_selected, count=page.item_count, facets=facets, placeholder=_('Search datasets...'), show_empty=request.params, fields=fields %}
 {% endblock %}
 {% block packages_list %}
-{% if c.page.items %}
-{{ h.snippet('snippets/package_list.html', packages=c.page.items) }}
+{% if page.items %}
+{{ h.snippet('snippets/package_list.html', packages=page.items) }}
 {% endif %}
 {% endblock %}
 {% block page_pagination %}
-{{ c.page.pager(q=c.q) }}
+{{ page.pager(q=q) }}
 {% endblock %}
 {% endblock %}
 
 {% block organization_facets %}
 <div class="filters">
     <div>
-    {% for facet in c.facet_titles %}
-    {{ h.snippet('snippets/facet_list.html', title=c.facet_titles[facet], name=facet, extras={'id':c.group_dict.id}) }}
+    {% for facet in facet_titles %}
+    {{ h.snippet('snippets/facet_list.html', title=facet_titles[facet], name=facet, extras={'id':group_dict.id}) }}
     {% endfor %}
     </div>
     <a class="close no-text hide-filters"><i class="fa fa-times"></i><span class="text">close</span></a>


### PR DESCRIPTION
https://github.com/GSA/datagov-deploy/issues/3672

Compared with template files in CKAN 2.9 core, it shows that ckan 2.9 template has stopped using pylons tmpl_context c.
https://docs.ckan.org/en/2.9/theming/variables-and-functions.html#tmpl_context