### PR TITLE
Update contact link page

### DIFF
--- a/ckanext/datagovtheme/templates/templates_new/package/read_base.html
+++ b/ckanext/datagovtheme/templates/templates_new/package/read_base.html
@@ -17,8 +17,7 @@
 
 {% block content_action %}
 <div class="btn-group actions">
-    <li> <a href="https://www.data.gov/story/?media_url={{g.site_url}}{{ h.url_for(controller='dataset', action='read', id=pkg.name) }}" class="btn btn-info"> <i class="fa fa-book"></i> Submit Data Story </a> </li>
-    <li> <a href="https://www.data.gov/issue/?media_url={{g.site_url}}{{ h.url_for(controller='dataset', action='read', id=pkg.name) }}" class="btn btn-warning"> <i class="fa fa-bullhorn"></i> Report Data Issue </a> </li>
+    <li> <a href="https://www.data.gov/contact" class="btn btn-warning"> <i class="fa fa-bullhorn"></i> Contact Data.gov </a> </li>
     {# NOTE: Not implemented in stage 1 #}
     {# <li>{% link_for _('History'), controller='dataset', action='history', id=pkg.name, class_='btn', icon='undo' %}</li> #}
     {% if h.check_access('package_update', {'id':pkg.id }) %}


### PR DESCRIPTION
Related to https://github.com/GSA/datagov-deploy/issues/3709.

We no longer have fine grain control over the contact page; it's a simple form.
We used to provide the information about the dataset and where it came from, but we can't do that with touchpoints hosted on our static site.
This simplifies to 1 button, and calls it "Contact data.gov".