### PR TITLE
show harvest source link

### DIFF
--- a/ckanext/datagovtheme/templates/templates_new/package/read.html
+++ b/ckanext/datagovtheme/templates/templates_new/package/read.html
@@ -270,7 +270,7 @@
             </li>
           {% endif %}
         </ul>
-        <!-- <p class="{{ 'text-muted' }}">{{ h.get_harvest_source_link(pkg) }}</p> -->
+        <p class="{{ 'text-muted' }}">{{ h.get_harvest_source_link(pkg) }}</p>
       </section>
     {% endif %}
   {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datagovtheme',
-    version='0.1.2',
+    version='0.1.3',
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
reverting https://github.com/GSA/ckanext-datagovtheme/pull/119

Harvest source link speed is decent on the 2xlarge type of RDS database, it is ok to show it.