### PR TITLE
remove the broken link from search page.

### DIFF
--- a/ckanext/datagovtheme/templates/package/search.html
+++ b/ckanext/datagovtheme/templates/package/search.html
@@ -52,9 +52,6 @@
             <p class="extra">Please try another search.</p>
             {% endtrans %}
             {% endif %}
-            {% if c.q != '' %}
-            <p class="extra"><b>You are searching in the list of datasets. Show results in <a href="//www.data.gov/search-results/?group=site&q={{c.q}}">entire Data.gov site</a>.</b></p>
-            {% endif %}
         </div>
     </form></div>
 <a class="show-filters btn btn-primary">{{ _('Filter Results') }}</a>
@@ -82,9 +79,6 @@
                 <b>
                     {% snippet 'snippets/search_result_text.html', query=c.q, count=c.page.item_count, type='dataset' %}
                 </b>
-                {% endif %}
-                {% if c.q != '' and c.page.item_count > 0 %}
-                <p class="extra"><b>You are searching in the list of datasets. Show results in <a href="//www.data.gov/search-results/?group=site&q={{c.q}}">entire Data.gov site</a>.</b></p>
                 {% endif %}
             </div>
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datagovtheme',
-    version='0.1.13',
+    version='0.1.14',
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
# Pull Request

related to https://github.com/GSA/data.gov/issues/4006

## About

remove the broken link from catalog as the static site search is not available.  

## PR TASKS

- [x] The actual code changes.
- [ ] ~Tests written and passed.~
- [ ] ~Any changes to docs?~
- [x] Bumped version number in [setup.py](https://github.com/GSA/ckanext-geodatagov/blob/1b1bad0b2ff06112e18c7f4f4fb1143baec1266a/setup.py#L13) (also checked on [PyPi](https://pypi.org/project/ckanext-geodatagov/#history)).