### PR TITLE
bump pypi publish action to current 1.8.5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
           python setup.py sdist
           python setup.py bdist_wheel
       - name: pypi-publish
-        uses: pypa/gh-action-pypi-publish@v1.5.1
+        uses: pypa/gh-action-pypi-publish@v1.8.5
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Related to [uh this](https://gsa-tts.slack.com/archives/C2N85536E/p1682442963882499), I guess. 

Looks like our current pypi action is a pypa/gh-action-pypi-publish@v1.5.1. Trying to fix the [build issue from this PR ](https://github.com/GSA/ckanext-datagovtheme/actions/runs/4801839779/jobs/8544632079)by bumping to [current `1.8.5`](https://github.com/pypa/gh-action-pypi-publish/releases/tag/v1.8.5)