### PR TITLE
Word wrap

### DIFF
--- a/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
@@ -2518,6 +2518,11 @@ ul#menu-footer li {
     padding-right: 1rem;
 }
 
+section.additional-info td.dataset-details {
+    max-width: 570px;
+    word-wrap: break-word;
+}
+
 /* override usws*/
 body .usa-banner__header-text,
 body .usa-banner__button-text {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ckanext-datagovtheme',
-    version='0.2.2',
+    version='0.2.3',
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
Additional-info looks bad for long lines. 
discussion in https://gsa-tts.slack.com/archives/C2N85536E/p1690816336929609

![image](https://github.com/GSA/ckanext-datagovtheme/assets/1392461/11bcda8e-e9c5-4db1-bb48-f9b774cc52e8)

This fix ensures string stays within a max-width and do proper wrapping.