### PR TITLE
fix dataset bottom margin

### DIFF
--- a/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
@@ -652,7 +652,7 @@ a {
     padding-bottom: 0px;
 }
 .module .module-content .dataset-list.unstyled .dataset-item .dataset-resources.unstyled {
-    margin-bottom: 30px;
+    margin-bottom: 10px;
 }
 .label {
     display: inline;
@@ -834,15 +834,14 @@ a.label:focus {
 }
 .dataset-item {
     position: relative;
-    padding-bottom: 0;
+    padding-bottom: 10px;
+    padding-top: 10px;
     margin-bottom: 0;
-    border-bottom-width: 0;
+    border-bottom-width: 0px;
+    border-top: 1px dotted #ddd;
 }
 .dataset-item .dataset-content {
-    padding: 0 0 30px 0;
-}
-.dataset-item .dataset-content {
-    padding: 0 0 30px 0;
+    padding: 0 0 10px 0;
 }
 .dataset-item .dataset-organization {
     display: inline;

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 
 # ckanext-harvest
--e git+https://github.com/ckan/ckanext-harvest.git@master#egg=ckanext_harvest
+-e git+https://github.com/ckan/ckanext-harvest.git@v1.5.6#egg=ckanext_harvest
 -e git+https://github.com/ckan/ckanext-spatial.git@master#egg=ckanext-spatial
 -e git+https://github.com/gsa/ckanext-geodatagov.git@main#egg=ckanext-geodatagov
 

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.2.5",
+    version="0.2.6",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4410
- reduced bottom margin in resources
- added padding in dataset-item
- added border to match vanilla ckan style

### Before:
![image](https://github.com/GSA/ckanext-datagovtheme/assets/1392461/b003c65d-69db-4ebc-ad72-2d662d64bae8)
### After:
![image](https://github.com/GSA/ckanext-datagovtheme/assets/1392461/da9d4cfc-3ec4-4d0f-af70-b6d72ea83de6)

### Before:
![image](https://github.com/GSA/ckanext-datagovtheme/assets/1392461/017d53f2-db79-496e-b403-f63a220170f9)
### After:
![image](https://github.com/GSA/ckanext-datagovtheme/assets/1392461/8e6eff30-9f2e-465a-862f-d9644e1db62b)

