### PR TITLE
Add other data resources section

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ syntax: glob
 .vscode/
 
 # Cypress
-cypress/e2e/videos/*
+cypress/videos/*
 cypress/e2e/screenshots/*
 cypress/e2e/results/output.xml
 node_modules

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -264,6 +264,16 @@ def render_datetime_datagov(date_str):
     return value
 
 
+def get_geoplatform_link(package_name):
+    url = f"https://stg-api.geoplatform.gov/v3/public/lookups/data-gov/dataset?name={package_name}"
+    try:
+        req = urllib.request.urlopen(url)
+        if req.getcode() == 200:
+            return json.loads(req.read())["geoplatform_url"]
+    except Exception:
+        pass
+
+
 def get_harvest_object_formats(harvest_object_id):
     try:
         obj = p.toolkit.get_action('harvest_object_show')({}, {'id': harvest_object_id})

--- a/ckanext/datagovtheme/plugin.py
+++ b/ckanext/datagovtheme/plugin.py
@@ -90,6 +90,7 @@ class DatagovTheme(p.SingletonPlugin):
             'datagovtheme_get_responsible_party': datagovtheme_helpers.get_responsible_party,
             'is_tagged_ngda': datagovtheme_helpers.is_tagged_ngda,
             'render_datetime_datagov': datagovtheme_helpers.render_datetime_datagov,
+            'get_geoplatform_link': datagovtheme_helpers.get_geoplatform_link,
             'get_harvest_object_formats': datagovtheme_helpers.get_harvest_object_formats,
             'get_bureau_info': datagovtheme_helpers.get_bureau_info,
             'get_harvest_source_link': datagovtheme_helpers.get_harvest_source_link,

--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -279,8 +279,12 @@
   {% set geoplatform_link = h.get_geoplatform_link(pkg_dict["name"]) %}
     {% if geoplatform_link %}
       <section id="dataset-other-resources" class="resources module-content">
-          <h3>Other Data Resources</h3>
-              <a href="{{ geoplatform_link }}">View this on Geoplatform</a>
+        <h3>Other Data Resources</h3>
+        <a href="https://www.geoplatform.gov/metadata/eee9c4c3-5d00-49aa-be4d-134de249f141" target="_blank">View this on Geoplatform</a>
+        <svg class="usa-icon" aria-hidden="true" role="img">
+            <use xlink:href="#svg-launch"></use>
+            <symbol viewBox="0 0 24 24" id="svg-launch" xmlns="http://www.w3.org/2000/svg"><path d="M19 19H5V5h7V3H5a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14c1.1 0 2-.9 2-2v-7h-2v7zM14 3v2h3.59l-9.83 9.83 1.41 1.41L19 6.41V10h2V3h-7z"></path></symbol>
+        </svg>
       </section>
   {% endif %}
   

--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -276,6 +276,14 @@
     {% endif %}
   {% endif %}
 
+  {% set geoplatform_link = h.get_geoplatform_link(pkg_dict["name"]) %}
+    {% if geoplatform_link %}
+      <section id="dataset-other-resources" class="resources module-content">
+          <h3>Other Data Resources</h3>
+              <a href="{{ geoplatform_link }}">View this on Geoplatform</a>
+      </section>
+  {% endif %}
+  
   {% set graphic_preview_file =h.get_pkg_dict_extra(pkg, 'graphic-preview-file', None) %}
   {% if graphic_preview_file and graphic_preview_file.lower()[:4] == 'http' %}
     <section id="dataset-graphic-preview" class="resources module-content">
@@ -284,7 +292,7 @@
       <img src="{{ h.get_pkg_dict_extra(pkg, 'graphic-preview-file') }}" alt="{{ graphic_preview_desc }}" title="{{ graphic_preview_desc }}" />
     </section>
   {% endif %}
-
+  
 {% endblock %}
 
 {% block package_additional_info %}

--- a/ckanext/datagovtheme/tests/test_helpers.py
+++ b/ckanext/datagovtheme/tests/test_helpers.py
@@ -136,3 +136,20 @@ def test_is_tagged_ngda():
 
     assert helpers.is_tagged_ngda(dataset_ngda) is True
     assert helpers.is_tagged_ngda(dataset_non_ngda) is False
+
+##################
+# other data resources
+##################
+
+
+@mock.patch("ckanext.datagovtheme.helpers.get_geoplatform_link")
+def test_is_on_geoplatform(mock_get_geoplatform_link):
+    """Assert that package is available on geoplatform"""
+
+    mock_get_geoplatform_link.return_value = {
+        "geoplatform_url": "https://stg.geoplatform.gov/metadata/36da2c52-1e55-5e9b-959b-7c415478c757"
+    }
+    assert helpers.get_geoplatform_link("u-s-hourly-precipitation-data2") is not None
+
+    mock_get_geoplatform_link.return_value = None
+    assert helpers.get_geoplatform_link("geoplatform_dataset") is None


### PR DESCRIPTION
refers to [#3478](https://github.com/GSA/data.gov/issues/3478)
- add helper function for grabbing package/dataset from geoplatform
- add "other data resources" section to package template with link to package on geoplatform.