### PR TITLE
Remove HTML metadata link

### DIFF
--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -249,12 +249,6 @@
             </strong>
             <p class="description">
               <a href="/harvest/object/{{ harvest_object_id }}">Download Metadata</a>
-              {% if ho_formats.object_format == 'ISO-19139' %}
-                {% if not dataset_is_datajson %}
-                  &middot;
-                  <a href="/harvest/object/{{ harvest_object_id }}/html">View Full Metadata</a>
-                {% endif %}
-              {% endif %}
             </p>
           </li>
           {% if ho_formats.original_format %}
@@ -265,8 +259,6 @@
               </strong>
               <p class="description">
                 <a href="/harvest/object/{{ harvest_object_id }}/original">Download Original Metadata</a>
-                &middot;
-                <a href="/harvest/object/{{ harvest_object_id }}/html/original">View Original Full Metadata</a>
               </p>
             </li>
           {% endif %}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.2.12",
+    version="0.2.13",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
Related to https://github.com/GSA/data.gov/issues/4597

This is super legacy code, and something that data.gov should not be responsible for. While we accept ISO and CSDGM metadata standards, we are not experts in them and should not be trying to display them in custom HTML formats. Hopefully the recent work to link to  link to Geoplatform (https://github.com/GSA/data.gov/issues/3478) will point to the experts in geospatial metadata.