### PR TITLE
more specific css selector for footer anchor color

### DIFF
--- a/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
@@ -111,7 +111,7 @@ body,
     border-radius: 0;
 }
 
-.usa-footer.site-footer a,
+.usa-footer.site-footer .footer-section-bottom a,
 a {
     color: #284a7a;
 }

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.2.14",
+    version="0.2.15",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
The footer link color is too dark after the latest change. This brings original color back.

![image](https://github.com/GSA/ckanext-datagovtheme/assets/1392461/0c6673fb-8c0f-4f8d-8edd-7c63ece115f0)
![image](https://github.com/GSA/ckanext-datagovtheme/assets/1392461/bc127b39-28f5-4e05-9ca2-bab4a05d5898)
