### PR TITLE
Ajax recent view

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,11 @@ CKAN version | Compatibility
 
 ### Configuration
 
-_TODO: what configuraiton options exist?_
+[Optional]
+`ckanext.datagovtheme.js_recent_view = true`
+
+
+This defaults to `false`. If displaying the recent view count slows down page loading, the optional parameter can be set to `true` to make the recent view count an AJAX call, improving page loading speed. If the recent view count information (package['tracking_summary']) is already present, the AJAX call is disabled to reduce overhead. Therefore, the built-in recent view count rendering must be disabled for this mechanism to take effect.
 
 
 ## Development

--- a/ckanext/datagovtheme/blueprint.py
+++ b/ckanext/datagovtheme/blueprint.py
@@ -3,13 +3,14 @@ import ckan.plugins as p
 from ckan.plugins.toolkit import config
 from ckan.lib.base import abort
 from ckan.common import c, request
+from ckanext.datagovtheme import helpers
 
-from flask import Blueprint, redirect
+from flask import Blueprint, redirect, jsonify
 
 import logging
 log = logging.getLogger(__name__)
 
-pusher = Blueprint('datagovtheme', __name__)
+datagovtheme_bp = Blueprint('datagovtheme', __name__)
 
 
 def show():
@@ -38,4 +39,12 @@ def redirect_homepage():
     return redirect(CKAN_SITE_URL + "/dataset", code=302)
 
 
-pusher.add_url_rule('/', view_func=redirect_homepage)
+def get_popuplar_count():
+    pkgs = request.args.get('pkgs')
+    return jsonify(helpers.get_pkgs_popular_count(pkgs))
+
+
+datagovtheme_bp.add_url_rule('/', view_func=redirect_homepage)
+datagovtheme_bp.add_url_rule("/datagovtheme/get-popular-count",
+                             methods=['GET'],
+                             view_func=get_popuplar_count)

--- a/ckanext/datagovtheme/blueprint.py
+++ b/ckanext/datagovtheme/blueprint.py
@@ -36,7 +36,7 @@ def show():
 
 def redirect_homepage():
     CKAN_SITE_URL = config.get("ckan.site_url")
-    return redirect(CKAN_SITE_URL + "/dataset", code=302)
+    return redirect(CKAN_SITE_URL + "/dataset/", code=302)
 
 
 def get_popuplar_count():

--- a/ckanext/datagovtheme/fanstatic_library/scripts/popular.js
+++ b/ckanext/datagovtheme/fanstatic_library/scripts/popular.js
@@ -1,0 +1,36 @@
+// This js file loads with datagov-popular.html snippet
+
+jQuery(function ($) {
+
+  // This api takes a list of package ids from querystring and returns the view count for each package
+  var pupolar_api = "/datagovtheme/get-popular-count";
+
+  // all ids in a string, comma separated
+  var pkgs = {'pkgs': collect_all_packages().join(',')};
+
+  $.getJSON(pupolar_api, pkgs, function(data) {
+    $.each( data, function( key, val ) {
+      $("ul.dataset-list li.dataset-item h3.dataset-heading").each(function() {
+        if ($(this).attr('pkg_id') == key) {
+          $(this).find('span.recent-views-datagov').attr('title', val['recent']).html('<i class="fa fa-line-chart"></i> ' + val['recent'] + ' recent views');
+          // If the view count is greater than 10, make it visible
+          if (val['recent'] >= 10) {
+            $(this).find('span.recent-views').css('visibility', 'visible');
+          }else{
+            $(this).find('span.recent-views').css('display', 'hidden');
+          }
+        }
+      });
+    });
+  });
+
+  // We have pkg_id in each dataset-item, added in the template.
+  function collect_all_packages() {
+    var pkgs = [];
+    $("ul.dataset-list li.dataset-item h3.dataset-heading").each(function() {
+      pkgs.push($(this).attr('pkg_id'));
+    });
+
+    return pkgs;
+  } 
+});

--- a/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
+++ b/ckanext/datagovtheme/fanstatic_library/styles/datagovtheme.css
@@ -2239,6 +2239,9 @@ body .tagged-ngda {
     padding-left: 5px;
     display: inline-block;
 }
+.recent-views-datagov {
+    visibility: hidden;
+}
 .bar-image {
     width: 18px;
     display: inline-block;

--- a/ckanext/datagovtheme/fanstatic_library/webassets.yml
+++ b/ckanext/datagovtheme/fanstatic_library/webassets.yml
@@ -38,3 +38,8 @@ location_autocomplete_js:
     # TODO can this custom location search be replaced by ckanext-spatial? Can
     # this be pushed upstream to ckanext-spatial as an enhancement?
     - scripts/location_autocomplete.js
+
+popular-js:
+  output: datagovtheme/popular.js
+  contents:
+    - scripts/popular.js

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -10,6 +10,7 @@ import urllib.request
 import pkg_resources
 
 from ckan import plugins as p
+from ckan.lib import base
 from ckan.lib import helpers as h
 from ckan import model
 from ckanext.harvest.model import HarvestObject
@@ -762,3 +763,24 @@ def get_login_url():
         return h.url_for(controller='user', action='login')
 
     return '/user/saml2login'
+
+
+def get_pkgs_popular_count(ids):
+    populars = {}
+    if ids:
+        pkg_ids = ids.split(',')
+        for pkg_id in pkg_ids:
+            populars[pkg_id] = model.TrackingSummary.get_for_package(pkg_id)
+    return populars
+
+
+def render_popular(type, pkg, min, title=''):
+    # If the package has tracking_summary, call core helper function to render it.
+    if pkg.get('tracking_summary'):
+        return h.popular(type, pkg['tracking_summary']['recent'], min, title)
+
+    js_recent_view = asbool(config.get('ckanext.datagovtheme.js_recent_view', False))
+    if js_recent_view:
+        return base.render_snippet('snippets/datagov_popular.html')
+
+    return ''

--- a/ckanext/datagovtheme/plugin.py
+++ b/ckanext/datagovtheme/plugin.py
@@ -109,6 +109,8 @@ class DatagovTheme(p.SingletonPlugin):
             'convert_top_category_to_list': datagovtheme_helpers.convert_top_category_to_list,
             'get_pkg_dict_extra': datagovtheme_helpers.get_pkg_dict_extra,
             'get_login_url': datagovtheme_helpers.get_login_url,
+            'get_pkgs_popular_count': datagovtheme_helpers.get_pkgs_popular_count,
+            'render_popular': datagovtheme_helpers.render_popular,
         }
 
         # https://github.com/GSA/ckan/blob/datagov/ckan/config/environment.py#L70:L70
@@ -125,4 +127,4 @@ class DatagovTheme(p.SingletonPlugin):
         return helpers
 
     def get_blueprint(self):
-        return blueprint.pusher
+        return blueprint.datagovtheme_bp

--- a/ckanext/datagovtheme/templates/package/snippets/resource_item.html
+++ b/ckanext/datagovtheme/templates/package/snippets/resource_item.html
@@ -14,12 +14,12 @@
   {% if res.name == 'Comma Seperated Values File' %}
     <a itemprop="contentUrl" class="heading" href="{{ url }}" title="Comma Separated Values File">
     Comma Separated Values File<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ res.format }}</span>
-    {{ h.popular('views', res.tracking_summary.total, min=10) }}
+    {{ h.popular('views', res.tracking_summary.total, min=10) if res.tracking_summary }}
     </a>
   {% else %}
     <a itemprop="contentUrl" class="heading" href="{{ url }}" title="{{ res.name or res.description }}">
     {{ h.resource_display_name(res) | truncate(50) }}<span class="format-label" property="dc:format" data-format="{{ res.format.lower() or 'data' }}">{{ res.format }}</span>
-    {{ h.popular('views', res.tracking_summary.total, min=10) }}
+    {{ h.popular('views', res.tracking_summary.total, min=10) if res.tracking_summary }}
     </a>
   {% endif %}
 {% endblock %}

--- a/ckanext/datagovtheme/templates/snippets/datagov_popular.html
+++ b/ckanext/datagovtheme/templates/snippets/datagov_popular.html
@@ -1,0 +1,5 @@
+<span class="recent-views recent-views-datagov" title="" xmlns="http://www.w3.org/1999/xhtml">
+  <i class="fa fa-line-chart"></i> &nbsp;&nbsp; recent views
+</span>
+{% asset 'datagovtheme/popular-js' %}
+

--- a/ckanext/datagovtheme/templates/snippets/package_item.html
+++ b/ckanext/datagovtheme/templates/snippets/package_item.html
@@ -35,7 +35,7 @@ Example:
         </span>
         </div>
       {% endif %}
-      <h3 class="dataset-heading">
+      <h3 class="dataset-heading" pkg_id="{{ package.id }}">
         {% if package.private %}
           <span class="dataset-private label label-inverse">
             <i class="fa fa-lock"></i>
@@ -63,7 +63,7 @@ Example:
         </span>
         {% endif %}
 
-        {{ h.popular('recent views', package.tracking_summary.recent, min=10) if package.tracking_summary }}
+        {{ h.render_popular('recent views', package, min=10) }}
       </h3>
       <div class="notes">
         {% if organization and show_organization %}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.2.24",
+    version="0.2.25",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4708 and https://github.com/GSA/data.gov/issues/4655
- an optional `ckanext.datagovtheme.js_recent_view` is added. If set to true, this will turn recent count info into AJAX call.
- add test
- redirect `/` to `/dataset/` with a trailing slash
- add documentation