### PR TITLE
Popular count fix

### DIFF
--- a/ckanext/datagovtheme/blueprint.py
+++ b/ckanext/datagovtheme/blueprint.py
@@ -39,7 +39,7 @@ def redirect_homepage():
     return redirect(CKAN_SITE_URL + "/dataset/", code=302)
 
 
-def get_popuplar_count():
+def get_popular_count():
     pkgs = request.args.get('pkgs')
     return jsonify(helpers.get_pkgs_popular_count(pkgs))
 
@@ -47,4 +47,4 @@ def get_popuplar_count():
 datagovtheme_bp.add_url_rule('/', view_func=redirect_homepage)
 datagovtheme_bp.add_url_rule("/datagovtheme/get-popular-count",
                              methods=['GET'],
-                             view_func=get_popuplar_count)
+                             view_func=get_popular_count)

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -9,14 +9,10 @@ import urllib.request
 
 import pkg_resources
 
-from ckan import plugins as p
-from ckan.lib import base
-from ckan.lib import helpers as h
-from ckan import model
+from ckan import plugins as p, model
+from ckan.lib import base, helpers as h
+from ckan.plugins.toolkit import asbool, config
 from ckanext.harvest.model import HarvestObject
-from ckan.plugins.toolkit import asbool
-
-from ckan.plugins.toolkit import config
 
 log = logging.getLogger(__name__)
 
@@ -770,6 +766,10 @@ def get_pkgs_popular_count(ids):
     if ids:
         pkg_ids = ids.split(',')
         for pkg_id in pkg_ids:
+            package = model.Package.get(pkg_id)
+            if not package or package.private:
+                continue
+            # only public package gets here
             populars[pkg_id] = model.TrackingSummary.get_for_package(pkg_id)
     return populars
 

--- a/ckanext/datagovtheme/tests/test_helpers.py
+++ b/ckanext/datagovtheme/tests/test_helpers.py
@@ -181,10 +181,14 @@ def update_tracking_summary():
 
 
 def test_get_pkgs_popular_count(track):
+    factories.Organization(name='myorg')
     factories.Dataset(id="view-id-1", name="view-id-1")
     factories.Dataset(id="view-id-2", name="view-id-2")
+    factories.Dataset(id="view-id-3", name="view-id-3", private=True, owner_org="myorg")
 
-    ids = "view-id-1,view-id-2"
+    ids = "view-id-1,view-id-2,view-id-3,view-id-4"
+    # before any views, all datasets should have 0 views
+    # private view-id-3 and non-existent view-id-4 should not be counted
     assert helpers.get_pkgs_popular_count(ids) == {
         'view-id-1': {'recent': 0, 'total': 0},
         'view-id-2': {'recent': 0, 'total': 0}

--- a/ckanext/datagovtheme/tests/test_helpers.py
+++ b/ckanext/datagovtheme/tests/test_helpers.py
@@ -181,10 +181,10 @@ def update_tracking_summary():
 
 
 def test_get_pkgs_popular_count(track):
-    factories.Organization(name='myorg')
+    factories.Organization(name='myorg1')
     factories.Dataset(id="view-id-1", name="view-id-1")
     factories.Dataset(id="view-id-2", name="view-id-2")
-    factories.Dataset(id="view-id-3", name="view-id-3", private=True, owner_org="myorg")
+    factories.Dataset(id="view-id-3", name="view-id-3", private=True, owner_org="myorg1")
 
     ids = "view-id-1,view-id-2,view-id-3,view-id-4"
     # before any views, all datasets should have 0 views

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.2.31",
+    version="0.2.32",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
`get_pkgs_popular_count` should only return view counts for valid datasets.
private dataset or non-existent dataset does not get anything.