### PR TITLE
Modify metadata source links

### DIFF
--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -326,31 +326,24 @@ def get_harvest_object_formats(harvest_object_id, dataset_is_datajson=False):
     }
 
 
-def get_harvest_source_link(package_dict):
+def get_harvest_source_link(package_dict, type='source'):
     harvest_source_id = get_pkg_dict_extra(package_dict, 'harvest_source_id', None)
     harvest_source_title = get_pkg_dict_extra(package_dict, 'harvest_source_title', None)
+    harvest_object_id = get_pkg_dict_extra(package_dict, 'harvest_object_id', None)
     harvest_admin_url = config.get('ckanext.datagovtheme.harvest_admin_url')
 
     if harvest_source_id and harvest_source_title:
         msg = p.toolkit._('Harvested from')
         harvest_next = asbool(config.get('ckanext.datagovtheme.harvest_next', 'false'))
-        if harvest_next:
-            url = f"{harvest_admin_url}/harvest_source/{harvest_source_id}"
+        if type == 'metadata':
+            url = f"{harvest_admin_url}/harvest_record/{harvest_object_id}/raw"
+            link = '<a href="{url}">{title}</a>'.format(url=url, title='Download Metadata')
         else:
-            url = h.url_for('harvest_read', id=harvest_source_id)
-        link = '{msg} <a href="{url}">{title}</a>'.format(url=url, msg=msg, title=harvest_source_title)
-        return p.toolkit.literal(link)
-
-    return ''
-
-
-def get_harvest_metadata_link(package_dict):
-    harvest_object_id = get_pkg_dict_extra(package_dict, 'harvest_object_id', None)
-    harvest_admin_url = config.get('ckanext.datagovtheme.harvest_admin_url')
-
-    if harvest_object_id:
-        url = f"{harvest_admin_url}/harvest_record/{harvest_object_id}/raw"
-        link = '<a href="{url}">{title}</a>'.format(url=url, title='Download Metadata')
+            if harvest_next:
+                url = f"{harvest_admin_url}/harvest_source/{harvest_source_id}"
+            else:
+                url = h.url_for('harvest_read', id=harvest_source_id)
+            link = '{msg} <a href="{url}">{title}</a>'.format(url=url, msg=msg, title=harvest_source_title)
         return p.toolkit.literal(link)
 
     return ''

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -329,15 +329,28 @@ def get_harvest_object_formats(harvest_object_id, dataset_is_datajson=False):
 def get_harvest_source_link(package_dict):
     harvest_source_id = get_pkg_dict_extra(package_dict, 'harvest_source_id', None)
     harvest_source_title = get_pkg_dict_extra(package_dict, 'harvest_source_title', None)
+    harvest_admin_url = config.get('ckanext.datagovtheme.harvest_admin_url')
 
     if harvest_source_id and harvest_source_title:
         msg = p.toolkit._('Harvested from')
         harvest_next = asbool(config.get('ckanext.datagovtheme.harvest_next', 'false'))
         if harvest_next:
-            url = h.url_for(f'/harvest/{harvest_source_id}')
+            url = f"{harvest_admin_url}/harvest_source/{harvest_source_id}"
         else:
             url = h.url_for('harvest_read', id=harvest_source_id)
         link = '{msg} <a href="{url}">{title}</a>'.format(url=url, msg=msg, title=harvest_source_title)
+        return p.toolkit.literal(link)
+
+    return ''
+
+
+def get_harvest_metadata_link(package_dict):
+    harvest_object_id = get_pkg_dict_extra(package_dict, 'harvest_object_id', None)
+    harvest_admin_url = config.get('ckanext.datagovtheme.harvest_admin_url')
+
+    if harvest_object_id:
+        url = f"{harvest_admin_url}/harvest_record/{harvest_object_id}/raw"
+        link = '<a href="{url}">{title}</a>'.format(url=url, title='Download Metadata')
         return p.toolkit.literal(link)
 
     return ''

--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -247,9 +247,7 @@
               {{ ho_formats.object_format }} Metadata
             {% endif %}
             </strong>
-            <p class="description">
-              <a href="/harvest/object/{{ harvest_object_id }}">Download Metadata</a>
-            </p>
+            <p class="description">{{ h.get_harvest_metadata_link(pkg) }}</p>
           </li>
           {% if ho_formats.original_format %}
             <li class="resource-item">

--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -247,7 +247,7 @@
               {{ ho_formats.object_format }} Metadata
             {% endif %}
             </strong>
-            <p class="description">{{ h.get_harvest_metadata_link(pkg) }}</p>
+            <p class="description">{{ h.get_harvest_source_link(pkg, 'metadata') }}</p>
           </li>
           {% if ho_formats.original_format %}
             <li class="resource-item">

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ lxml>=2.3
 argparse
 pyparsing>=2.1.10
 requests>=1.1.0
-pyproj
+pyproj=3.6.1
 Shapely==2.0.1
 numpy==1.26.4
 OWSLib==0.28.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ lxml>=2.3
 argparse
 pyparsing>=2.1.10
 requests>=1.1.0
-pyproj=3.6.1
+pyproj==3.6.1
 Shapely==2.0.1
 numpy==1.26.4
 OWSLib==0.28.1


### PR DESCRIPTION
Modified links in the metadata source section for both the `Download Metadata` and `harvest source` URLs from the Harvest admin app.