### PR TITLE
introduce collection_info

### DIFF
--- a/ckanext/datagovtheme/templates/package/search.html
+++ b/ckanext/datagovtheme/templates/package/search.html
@@ -10,7 +10,7 @@
     </div>
 
     <form id="dataset-search" class="search-form clearfix" method="get" data-module="select-switch">
-        {% set search_placeholder = 'Search collection...' if request.args.collection_package_id else 'Search datasets...' %}
+        {% set search_placeholder = 'Search collection...' if request.args.collection_info else 'Search datasets...' %}
         <span class="control-group search-giant">
           <label for="search-big" class="hide">{{ _('Search datasets') }}</label>
           <input id="search-big" type="text" class="search" name="q" value="{{ c.q }}" autocomplete="off" placeholder="{{ search_placeholder }}" onblur="if(value=='') value = 'Search datasets...'" onfocus="if(value=='Search datasets...') value = ''"/>
@@ -27,7 +27,7 @@
         <div class="results">
             <div class="filter-list">
                 {% for field in c.fields_grouped %}
-                {% if field != 'collection_package_id' %}
+                {% if field != 'collection_info' %}
                 <span class="facet">{{ c.facet_titles.get(field) }}:</span>
                 {% set search_facets_items = c.search_facets.get(field)['items'] %}
                 {% for value in c.fields_grouped[field] %}


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/4970

Use `collection_info`. No no more `collection_package_id` in catalog-next.  