### PR TITLE
Add missing meta description tag.

### DIFF
--- a/ckanext/datagovtheme/templates/snippets/link_preview.html
+++ b/ckanext/datagovtheme/templates/snippets/link_preview.html
@@ -22,6 +22,9 @@
     {% set notes = h.markdown_extract(org.description, 180) %}
   {% endif %}
 
+  <!-- Common Meta Tags -->
+  <meta property="description" content="{{ notes | forceescape }}">
+
   <!-- Facebook Meta Tags -->
   <meta property="og:url" content="https://data.gov">
   <meta property="og:type" content="website">


### PR DESCRIPTION
Issue:
GSA/data.gov#5076

Changes:

- Adds missing `meta` description tag.

![Screenshot from 2025-02-28 10-04-02](https://github.com/user-attachments/assets/16db44b3-eb2b-498e-a12d-58c8add903b7)
_(Screenshot of the `meta` description tag being populated on catalog home page. Content of the description tag matches the pre-existing Facebook/OpenGraph Meta Description also seen in screenshot)_
![Screenshot from 2025-02-28 10-04-37](https://github.com/user-attachments/assets/a18279b1-8a6d-447d-b7ed-fb4cb648dfe9)
_(Screenshot of the `meta` description tag being populated on catalog dataset page. Content of the description tag matches the pre-existing Facebook/OpenGraph Meta Description tag also seen in screenshot)_
