### PR TITLE
bump version to 0.2.42

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.2.41",
+    version="0.2.42",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
Reference to:
PR https://github.com/GSA/ckanext-datagovtheme/pull/223

Changes:
- bumps the version number from 0.2.41 -> 0.2.42