### PR TITLE
Fix `property` to be `name` for Meta Description

### DIFF
--- a/ckanext/datagovtheme/templates/snippets/link_preview.html
+++ b/ckanext/datagovtheme/templates/snippets/link_preview.html
@@ -1,42 +1,41 @@
-
 {% block open_graph_previews %}
-  <!-- Set defaults -->
-  {% set dataset = "Data.gov Dataset" %}
-  {% set organization = "Data.gov" %}
-  {% set notes = "The Home of the U.S. Government's Open Data" %}
-  {% set img = "https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/hero-image-bg.png" %}
+<!-- Set defaults -->
+{% set dataset = "Data.gov Dataset" %}
+{% set organization = "Data.gov" %}
+{% set notes = "The Home of the U.S. Government's Open Data" %}
+{% set img = "https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/hero-image-bg.png" %}
 
-  <!-- Set if pkg -->
-  {% set pkg = c.pkg_dict %}
-  {% if pkg %}
-    {% set dataset = pkg.title or pkg.name %}
-    {% set organization = pkg.organization.title or pkg.organization.name %}
-    {% set notes = h.markdown_extract(pkg.notes, 180) %}
-  {% endif %}
+<!-- Set if pkg -->
+{% set pkg = c.pkg_dict %}
+{% if pkg %}
+{% set dataset = pkg.title or pkg.name %}
+{% set organization = pkg.organization.title or pkg.organization.name %}
+{% set notes = h.markdown_extract(pkg.notes, 180) %}
+{% endif %}
 
-  <!-- Set if org -->
-  {% set org = c.group_dict %}
-  {% if org %}
-    {% set dataset = "Data.gov Organization" %}
-    {% set organization = org.title or org.name %}
-    {% set notes = h.markdown_extract(org.description, 180) %}
-  {% endif %}
+<!-- Set if org -->
+{% set org = c.group_dict %}
+{% if org %}
+{% set dataset = "Data.gov Organization" %}
+{% set organization = org.title or org.name %}
+{% set notes = h.markdown_extract(org.description, 180) %}
+{% endif %}
 
-  <!-- Common Meta Tags -->
-  <meta property="description" content="{{ notes | forceescape }}">
+<!-- Common Meta Tags -->
+<meta name="description" content="{{ notes | forceescape }}">
 
-  <!-- Facebook Meta Tags -->
-  <meta property="og:url" content="https://data.gov">
-  <meta property="og:type" content="website">
-  <meta property="og:title" content="{{ organization | forceescape }} - {{ dataset | forceescape }}">
-  <meta property="og:description" content="{{ notes | forceescape }}">
-  <meta property="og:image" content="{{ img }}">
+<!-- Facebook Meta Tags -->
+<meta property="og:url" content="https://data.gov">
+<meta property="og:type" content="website">
+<meta property="og:title" content="{{ organization | forceescape }} - {{ dataset | forceescape }}">
+<meta property="og:description" content="{{ notes | forceescape }}">
+<meta property="og:image" content="{{ img }}">
 
-  <!-- Twitter Meta Tags -->
-  <meta name="twitter:card" content="summary_large_image">
-  <meta property="twitter:domain" content="data.gov">
-  <meta property="twitter:url" content="https://data.gov">
-  <meta name="twitter:title" content="{{ organization | forceescape }} - {{ dataset | forceescape }}">
-  <meta name="twitter:description" content="{{ notes | forceescape }}">
-  <meta name="twitter:image" content="{{ img }}">
+<!-- Twitter Meta Tags -->
+<meta name="twitter:card" content="summary_large_image">
+<meta property="twitter:domain" content="data.gov">
+<meta property="twitter:url" content="https://data.gov">
+<meta name="twitter:title" content="{{ organization | forceescape }} - {{ dataset | forceescape }}">
+<meta name="twitter:description" content="{{ notes | forceescape }}">
+<meta name="twitter:image" content="{{ img }}">
 {% endblock %}

--- a/ckanext/datagovtheme/templates/snippets/link_preview.html
+++ b/ckanext/datagovtheme/templates/snippets/link_preview.html
@@ -1,41 +1,42 @@
+
 {% block open_graph_previews %}
-<!-- Set defaults -->
-{% set dataset = "Data.gov Dataset" %}
-{% set organization = "Data.gov" %}
-{% set notes = "The Home of the U.S. Government's Open Data" %}
-{% set img = "https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/hero-image-bg.png" %}
+  <!-- Set defaults -->
+  {% set dataset = "Data.gov Dataset" %}
+  {% set organization = "Data.gov" %}
+  {% set notes = "The Home of the U.S. Government's Open Data" %}
+  {% set img = "https://s3-us-gov-west-1.amazonaws.com/cg-0817d6e3-93c4-4de8-8b32-da6919464e61/hero-image-bg.png" %}
 
-<!-- Set if pkg -->
-{% set pkg = c.pkg_dict %}
-{% if pkg %}
-{% set dataset = pkg.title or pkg.name %}
-{% set organization = pkg.organization.title or pkg.organization.name %}
-{% set notes = h.markdown_extract(pkg.notes, 180) %}
-{% endif %}
+  <!-- Set if pkg -->
+  {% set pkg = c.pkg_dict %}
+  {% if pkg %}
+    {% set dataset = pkg.title or pkg.name %}
+    {% set organization = pkg.organization.title or pkg.organization.name %}
+    {% set notes = h.markdown_extract(pkg.notes, 180) %}
+  {% endif %}
 
-<!-- Set if org -->
-{% set org = c.group_dict %}
-{% if org %}
-{% set dataset = "Data.gov Organization" %}
-{% set organization = org.title or org.name %}
-{% set notes = h.markdown_extract(org.description, 180) %}
-{% endif %}
+  <!-- Set if org -->
+  {% set org = c.group_dict %}
+  {% if org %}
+    {% set dataset = "Data.gov Organization" %}
+    {% set organization = org.title or org.name %}
+    {% set notes = h.markdown_extract(org.description, 180) %}
+  {% endif %}
 
-<!-- Common Meta Tags -->
-<meta name="description" content="{{ notes | forceescape }}">
+  <!-- Common Meta Tags -->
+  <meta name="description" content="{{ notes | forceescape }}">
 
-<!-- Facebook Meta Tags -->
-<meta property="og:url" content="https://data.gov">
-<meta property="og:type" content="website">
-<meta property="og:title" content="{{ organization | forceescape }} - {{ dataset | forceescape }}">
-<meta property="og:description" content="{{ notes | forceescape }}">
-<meta property="og:image" content="{{ img }}">
+  <!-- Facebook Meta Tags -->
+  <meta property="og:url" content="https://data.gov">
+  <meta property="og:type" content="website">
+  <meta property="og:title" content="{{ organization | forceescape }} - {{ dataset | forceescape }}">
+  <meta property="og:description" content="{{ notes | forceescape }}">
+  <meta property="og:image" content="{{ img }}">
 
-<!-- Twitter Meta Tags -->
-<meta name="twitter:card" content="summary_large_image">
-<meta property="twitter:domain" content="data.gov">
-<meta property="twitter:url" content="https://data.gov">
-<meta name="twitter:title" content="{{ organization | forceescape }} - {{ dataset | forceescape }}">
-<meta name="twitter:description" content="{{ notes | forceescape }}">
-<meta name="twitter:image" content="{{ img }}">
+  <!-- Twitter Meta Tags -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta property="twitter:domain" content="data.gov">
+  <meta property="twitter:url" content="https://data.gov">
+  <meta name="twitter:title" content="{{ organization | forceescape }} - {{ dataset | forceescape }}">
+  <meta name="twitter:description" content="{{ notes | forceescape }}">
+  <meta name="twitter:image" content="{{ img }}">
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.2.42",
+    version="0.2.43",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
Ref: GSA/data.gov#5076

Changes:

- Fixes the mistake of using `property` instead of `name`
    ex: `<meta name="description" content="Data.gov description example.">`