### PR TITLE
show next run

### DIFF
--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -12,7 +12,7 @@ import pkg_resources
 from ckan import plugins as p, model
 from ckan.lib import base, helpers as h
 from ckan.plugins.toolkit import asbool, config
-from ckanext.harvest.model import HarvestObject
+from ckanext.harvest.model import HarvestSource, HarvestObject
 from ckanext.tracking.model import TrackingSummary
 import ckanext.tracking.helpers as tracking_helpers
 
@@ -261,6 +261,11 @@ def render_datetime_datagov(date_str):
     except (ValueError, TypeError):
         return date_str
     return value
+
+
+def get_next_run(harvest_source_id):
+    source = HarvestSource.get(harvest_source_id)
+    return source.next_run.strftime('%Y-%m-%d %H:%M:%S') if source.next_run else ''
 
 
 def get_harvest_object_formats(harvest_object_id):

--- a/ckanext/datagovtheme/plugin.py
+++ b/ckanext/datagovtheme/plugin.py
@@ -90,6 +90,7 @@ class DatagovTheme(p.SingletonPlugin):
             'datagovtheme_get_responsible_party': datagovtheme_helpers.get_responsible_party,
             'is_tagged_ngda': datagovtheme_helpers.is_tagged_ngda,
             'render_datetime_datagov': datagovtheme_helpers.render_datetime_datagov,
+            'get_next_run': datagovtheme_helpers.get_next_run,
             'get_harvest_object_formats': datagovtheme_helpers.get_harvest_object_formats,
             'get_bureau_info': datagovtheme_helpers.get_bureau_info,
             'get_harvest_source_link': datagovtheme_helpers.get_harvest_source_link,

--- a/ckanext/datagovtheme/templates/package/snippets/additional_info.html
+++ b/ckanext/datagovtheme/templates/package/snippets/additional_info.html
@@ -4,6 +4,7 @@
 #}
 
 {% set pkg_count = h.package_count_for_source(pkg_dict.id) %}
+{% set next_run = h.get_next_run(pkg_dict.id) %}
 
 <section class="module-content additional-info">
   <h3>{{ _('Harvest Source') }}</h3>
@@ -62,6 +63,16 @@
           <th scope="row" class="dataset-label">{{ _('Harvesting Frequency') }}</th>
           <td class="dataset-details">{{ pkg_dict.frequency }}</td>
         </tr>
+
+        {% if next_run %}
+          <tr>
+            <th scope="row" class="dataset-label">{{ _('Next Job Scheduled') }}</th>
+            <td class="dataset-details">
+              {% snippet 'snippets/local_friendly_datetime.html', datetime_obj=next_run %}
+            </td>
+          </tr>
+        {% endif %}
+
         <tr>
           <th scope="row" class="dataset-label">{{ _('Source Type') }}</th>
           <td class="dataset-details">{{ pkg_dict.source_type }}</td>

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.3.3",
+    version="0.3.4",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
For https://gsa-tts.slack.com/archives/C2N85536E/p1743107715407289

Add **Next Job Scheduled** as useful info to display on harvest source about page. 