### PR TITLE
Remove the side map condition that filters out datajson datasets

### DIFF
--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -46,7 +46,7 @@
 {% block secondary_content %}
   {{ super() }}
   {% set dataset_extent = h.get_pkg_dict_extra(c.pkg_dict, 'spatial', '') %}
-  {% if dataset_extent and not h.get_pkg_dict_extra(c.pkg_dict, 'source_datajson_identifier', '') %}
+  {% if dataset_extent %}
     {% snippet "spatial/snippets/dataset_map_sidebar.html", extent=dataset_extent %}
   {% endif %}
 {% endblock %}

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.3.5",
+    version="0.3.6",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
Removed the condition in the side map logic that filters out  datajson datasets sources.

related issue: https://github.com/GSA/data.gov/issues/5134