### PR TITLE
Escape contents of description field for JSON-LD

### DIFF
--- a/ckanext/datagovtheme/templates/snippets/jsonld.html
+++ b/ckanext/datagovtheme/templates/snippets/jsonld.html
@@ -5,7 +5,8 @@
   {% if pkg %}
     {% set dataset = pkg.title or pkg.name or "Data.gov Dataset" %}
     {% set organization = pkg.organization.title or pkg.organization.name or "Data.gov" %}
-    {% set notes = h.markdown_extract(pkg.notes, 180) or "The Home of the U.S. Government's Open Data" %}
+    {# notes has to be JSON-escaped here #}
+    {% set notes = h.markdown_extract(h.escape_js(pkg.notes), 180) or "The Home of the U.S. Government's Open Data" %}
 
 
     <script type="application/ld+json" class="jsonld-website">

--- a/ckanext/datagovtheme/tests/test_notes.py
+++ b/ckanext/datagovtheme/tests/test_notes.py
@@ -23,3 +23,15 @@ class TestNotes(object):
 
         assert '<div itemprop="description" class="notes embedded-content">' in dataset_response.body
         assert notes in dataset_response.body
+
+    def test_datagovtheme_escapes_notes(self, app):
+        notes = 'Notes with a quote (")'
+        name = 'random_test' + str(int(time.time()))
+        organization = factories.Organization(name=name)
+        dataset = factories.Dataset(notes=notes, name=name, owner_org=organization['id'])
+
+        dataset_response = app.get('/dataset/{}'.format(dataset['name']))
+
+        # JSON-LD element needs to escape the quote mark in notes
+        print(dataset_response.body)
+        assert '"description": "Notes with a quote (\\")"' in dataset_response.body

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.3.6",
+    version="0.3.7",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
We saw an error on Google Search console about un-parseable structured data where a dataset uses a quote in their description field. We should be escaping those descriptions when we put them into JSON-LD structured data.

This adds the code to escape them and a test case that it has happened.

After merging, the version of this extension that catalog uses will need to be updated.