### PR TITLE
refresh session

### DIFF
--- a/ckanext/datagovtheme/blueprint.py
+++ b/ckanext/datagovtheme/blueprint.py
@@ -4,7 +4,7 @@ from ckan.plugins.toolkit import config
 from ckan.lib.base import abort
 from ckan.common import c, request
 
-from flask import Blueprint, redirect
+from flask import Blueprint, redirect, session
 
 import logging
 log = logging.getLogger(__name__)
@@ -39,3 +39,9 @@ def redirect_homepage():
 
 
 pusher.add_url_rule('/', view_func=redirect_homepage)
+
+
+@pusher.before_app_request
+def refresh_session():
+    """ Refresh session expiration time on each request """
+    session.modified = True

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.3.7",
+    version="0.3.8",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
For https://github.com/GSA/data.gov/issues/5253

session is refreshed at each visit so that active user does not get logged out prematurely. 

Similar to
- https://github.com/GSA/inventory-app/pull/811/commits/185b6c8bf47e90121eb95f6f48f0a94f310cec01
