### PR TITLE
Adds common linting (`black`, and `isort`)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ clean: ## Clean workspace and containers
 	CKAN_VERSION=$(CKAN_VERSION) docker compose  -f $(COMPOSE_FILE) down -v --remove-orphans
 
 lint: ## Lint the code (python 3 only)
-	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) run --rm ckan flake8 ckanext --count --show-source --statistics --exclude ckan
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) run --rm ckan flake8 ckanext --count --show-source --statistics --exclude ckan --ignore=W503
 
 test: ## Run extension tests
 	CKAN_VERSION=$(CKAN_VERSION) docker compose  -f $(COMPOSE_FILE) run --rm ckan ./test.sh
@@ -22,6 +22,9 @@ ui-interactive:
 
 up: ## Start the containers
 	CKAN_VERSION=$(CKAN_VERSION) docker compose  -f $(COMPOSE_FILE) up
+
+down: ## Stop the containers
+	CKAN_VERSION=$(CKAN_VERSION) docker compose -f $(COMPOSE_FILE) down
 
 upd: ## Start the containers in the background
 	CKAN_VERSION=$(CKAN_VERSION) docker compose  -f $(COMPOSE_FILE) run --rm ckan ckan search-index rebuild -i -o -e

--- a/ckanext/__init__.py
+++ b/ckanext/__init__.py
@@ -1,7 +1,9 @@
 # this is a namespace package
 try:
     import pkg_resources
+
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
+
     __path__ = pkgutil.extend_path(__path__, __name__)

--- a/ckanext/datagovtheme/__init__.py
+++ b/ckanext/datagovtheme/__init__.py
@@ -1,7 +1,9 @@
 # this is a namespace package
 try:
     import pkg_resources
+
     pkg_resources.declare_namespace(__name__)
 except ImportError:
     import pkgutil
+
     __path__ = pkgutil.extend_path(__path__, __name__)

--- a/ckanext/datagovtheme/blueprint.py
+++ b/ckanext/datagovtheme/blueprint.py
@@ -1,36 +1,38 @@
+import logging
 import urllib.parse
-import ckan.plugins as p
-from ckan.plugins.toolkit import config
-from ckan.lib.base import abort
-from ckan.common import c, request
 
+import ckan.plugins as p
+from ckan.common import c, request
+from ckan.lib.base import abort
+from ckan.plugins.toolkit import config
 from flask import Blueprint, redirect
 
-import logging
 log = logging.getLogger(__name__)
 
-pusher = Blueprint('datagovtheme', __name__)
+pusher = Blueprint("datagovtheme", __name__)
 
 
 def show():
     # TODO rename config option to ckanext.datagovtheme
-    viewer_url = config.get('ckanext.geodatagov.spatial_preview.url')
+    viewer_url = config.get("ckanext.geodatagov.spatial_preview.url")
 
     if not viewer_url:
-        abort(500, 'Viewer URL not defined')
+        abort(500, "Viewer URL not defined")
 
     params_to_forward = {}
-    viewer_params = ['url', 'servicetype', 'srs']
+    viewer_params = ["url", "servicetype", "srs"]
 
     for key, value in request.params.items():
         if key.lower() in viewer_params:
             params_to_forward[key] = value
 
-    params_to_forward['mode'] = 'advanced'
+    params_to_forward["mode"] = "advanced"
 
-    c.viewer_url = '{0}?{1}'.format(viewer_url.strip('?'), urllib.parse.urlencode(params_to_forward))
+    c.viewer_url = "{0}?{1}".format(
+        viewer_url.strip("?"), urllib.parse.urlencode(params_to_forward)
+    )
 
-    return p.toolkit.render('viewer.html')
+    return p.toolkit.render("viewer.html")
 
 
 def redirect_homepage():
@@ -38,4 +40,4 @@ def redirect_homepage():
     return redirect(CKAN_SITE_URL + "/dataset/", code=302)
 
 
-pusher.add_url_rule('/', view_func=redirect_homepage)
+pusher.add_url_rule("/", view_func=redirect_homepage)

--- a/ckanext/datagovtheme/helpers.py
+++ b/ckanext/datagovtheme/helpers.py
@@ -5,14 +5,15 @@ import logging
 import os
 import re
 import urllib.parse
-from collections import namedtuple, Counter
-
-import pkg_resources
+from collections import Counter, namedtuple
 
 import ckan.logic as logic
-from ckan import plugins as p, model
+import pkg_resources
+from ckan import model
+from ckan import plugins as p
 from ckan.lib import helpers as h
 from ckan.plugins.toolkit import asbool, config
+
 from ckanext.harvest.model import HarvestObject
 
 log = logging.getLogger(__name__)
@@ -24,234 +25,228 @@ log = logging.getLogger(__name__)
 # otherwise fallback to an alternative.
 RESOURCE_MAPPING = {
     # ArcGIS File Types
-    'esri rest': ('Esri REST', 'Esri REST API Endpoint'),
-    'arcgis_rest': ('Esri REST', 'Esri REST API Endpoint'),
-    'web map application': ('ArcGIS Online Map', 'ArcGIS Online Map'),
-    'arcgis map preview': ('ArcGIS Map Preview', 'ArcGIS Map Preview'),
-    'arcgis map service': ('ArcGIS Map Service', 'ArcGIS Map Service'),
-    'wms': ('WMS', 'ArcGIS Web Mapping Service'),
-    'wfs': ('WFS', 'ArcGIS Web Feature Service'),
-    'wcs': ('WCS', 'Web Coverage Service'),
-
+    "esri rest": ("Esri REST", "Esri REST API Endpoint"),
+    "arcgis_rest": ("Esri REST", "Esri REST API Endpoint"),
+    "web map application": ("ArcGIS Online Map", "ArcGIS Online Map"),
+    "arcgis map preview": ("ArcGIS Map Preview", "ArcGIS Map Preview"),
+    "arcgis map service": ("ArcGIS Map Service", "ArcGIS Map Service"),
+    "wms": ("WMS", "ArcGIS Web Mapping Service"),
+    "wfs": ("WFS", "ArcGIS Web Feature Service"),
+    "wcs": ("WCS", "Web Coverage Service"),
     # CSS File Types
-    'css': ('CSS', 'Cascading Style Sheet File'),
-    'text/css': ('CSS', 'Cascading Style Sheet File'),
-
+    "css": ("CSS", "Cascading Style Sheet File"),
+    "text/css": ("CSS", "Cascading Style Sheet File"),
     # CSV File Types
-    'csv': ('CSV', 'Comma Separated Values File'),
-    'text/csv': ('CSV', 'Comma Separated Values File'),
-
+    "csv": ("CSV", "Comma Separated Values File"),
+    "text/csv": ("CSV", "Comma Separated Values File"),
     # EXE File Types
-    'exe': ('EXE', 'Windows Executable Program'),
-    'application/x-msdos-program': ('EXE', 'Windows Executable Program'),
-
+    "exe": ("EXE", "Windows Executable Program"),
+    "application/x-msdos-program": ("EXE", "Windows Executable Program"),
     # HyperText Markup Language (HTML) File Types
-    'htx': ('HTML', 'Web Page'),
-    'htm': ('HTML', 'Web Page'),
-    'html': ('HTML', 'Web Page'),
-    'htmls': ('HTML', 'Web Page'),
-    'xhtml': ('HTML', 'Web Page'),
-    'text/html': ('HTML', 'Web Page'),
-    'application/xhtml+xml': ('HTML', 'Web Page'),
-    'application/x-httpd-php': ('HTML', 'Web Page'),
-
+    "htx": ("HTML", "Web Page"),
+    "htm": ("HTML", "Web Page"),
+    "html": ("HTML", "Web Page"),
+    "htmls": ("HTML", "Web Page"),
+    "xhtml": ("HTML", "Web Page"),
+    "text/html": ("HTML", "Web Page"),
+    "application/xhtml+xml": ("HTML", "Web Page"),
+    "application/x-httpd-php": ("HTML", "Web Page"),
     # Image File Types - BITMAP
-    'bm': ('BMP', 'Bitmap Image File'),
-    'bmp': ('BMP', 'Bitmap Image File'),
-    'pbm': ('BMP', 'Bitmap Image File'),
-    'xbm': ('BMP', 'Bitmap Image File'),
-    'image/bmp': ('BMP', 'Bitmap Image File'),
-    'image/x-ms-bmp': ('BMP', 'Bitmap Image File'),
-    'image/x-xbitmap': ('BMP', 'Bitmap Image File'),
-    'image/x-windows-bmp': ('BMP', 'Bitmap Image File'),
-    'image/x-portable-bitmap': ('BMP', 'Bitmap Image File'),
-
+    "bm": ("BMP", "Bitmap Image File"),
+    "bmp": ("BMP", "Bitmap Image File"),
+    "pbm": ("BMP", "Bitmap Image File"),
+    "xbm": ("BMP", "Bitmap Image File"),
+    "image/bmp": ("BMP", "Bitmap Image File"),
+    "image/x-ms-bmp": ("BMP", "Bitmap Image File"),
+    "image/x-xbitmap": ("BMP", "Bitmap Image File"),
+    "image/x-windows-bmp": ("BMP", "Bitmap Image File"),
+    "image/x-portable-bitmap": ("BMP", "Bitmap Image File"),
     # Image File Types - Graphics Interchange Format (GIF)
-    'gif': ('GIF', 'GIF Image File'),
-    'image/gif': ('GIF', 'GIF Image File'),
-
+    "gif": ("GIF", "GIF Image File"),
+    "image/gif": ("GIF", "GIF Image File"),
     # Image File Types - ICON
-    'ico': ('ICO', 'Icon Image File'),
-    'image/x-icon': ('ICO', 'Icon Image File'),
-
+    "ico": ("ICO", "Icon Image File"),
+    "image/x-icon": ("ICO", "Icon Image File"),
     # Image File Types - JPEG
-    'jpe': ('JPEG', 'JPEG Image File'),
-    'jpg': ('JPEG', 'JPEG Image File'),
-    'jps': ('JPEG', 'JPEG Image File'),
-    'jpeg': ('JPEG', 'JPEG Image File'),
-    'pjpeg': ('JPEG', 'JPEG Image File'),
-    'image/jpeg': ('JPEG', 'JPEG Image File'),
-    'image/pjpeg': ('JPEG', 'JPEG Image File'),
-    'image/x-jps': ('JPEG', 'JPEG Image File'),
-    'image/x-citrix-jpeg': ('JPEG', 'JPEG Image File'),
-
+    "jpe": ("JPEG", "JPEG Image File"),
+    "jpg": ("JPEG", "JPEG Image File"),
+    "jps": ("JPEG", "JPEG Image File"),
+    "jpeg": ("JPEG", "JPEG Image File"),
+    "pjpeg": ("JPEG", "JPEG Image File"),
+    "image/jpeg": ("JPEG", "JPEG Image File"),
+    "image/pjpeg": ("JPEG", "JPEG Image File"),
+    "image/x-jps": ("JPEG", "JPEG Image File"),
+    "image/x-citrix-jpeg": ("JPEG", "JPEG Image File"),
     # Image File Types - PNG
-    'png': ('PNG', 'PNG Image File'),
-    'x-png': ('PNG', 'PNG Image File'),
-    'image/png': ('PNG', 'PNG Image File'),
-    'image/x-citrix-png': ('PNG', 'PNG Image File'),
-
+    "png": ("PNG", "PNG Image File"),
+    "x-png": ("PNG", "PNG Image File"),
+    "image/png": ("PNG", "PNG Image File"),
+    "image/x-citrix-png": ("PNG", "PNG Image File"),
     # Image File Types - Scalable Vector Graphics (SVG)
-    'svg': ('SVG', 'SVG Image File'),
-    'image/svg+xml': ('SVG', 'SVG Image File'),
-
+    "svg": ("SVG", "SVG Image File"),
+    "image/svg+xml": ("SVG", "SVG Image File"),
     # Image File Types - Tagged Image File Format (TIFF)
-    'tif': ('TIFF', 'TIFF Image File'),
-    'tiff': ('TIFF', 'TIFF Image File'),
-    'image/tiff': ('TIFF', 'TIFF Image File'),
-    'image/x-tiff': ('TIFF', 'TIFF Image File'),
-
+    "tif": ("TIFF", "TIFF Image File"),
+    "tiff": ("TIFF", "TIFF Image File"),
+    "image/tiff": ("TIFF", "TIFF Image File"),
+    "image/x-tiff": ("TIFF", "TIFF Image File"),
     # JSON File Types
-    'json': ('JSON', 'JSON File'),
-    'text/x-json': ('JSON', 'JSON File'),
-    'application/json': ('JSON', 'JSON File'),
-
+    "json": ("JSON", "JSON File"),
+    "text/x-json": ("JSON", "JSON File"),
+    "application/json": ("JSON", "JSON File"),
     # KML File Types
-    'kml': ('KML', 'KML File'),
-    'kmz': ('KML', 'KMZ File'),
-    'application/vnd.google-earth.kml+xml': ('KML', 'KML File'),
-    'application/vnd.google-earth.kmz': ('KML', 'KMZ File'),
-
+    "kml": ("KML", "KML File"),
+    "kmz": ("KML", "KMZ File"),
+    "application/vnd.google-earth.kml+xml": ("KML", "KML File"),
+    "application/vnd.google-earth.kmz": ("KML", "KMZ File"),
     # MS Access File Types
-    'mdb': ('ACCESS', 'MS Access Database'),
-    'access': ('ACCESS', 'MS Access Database'),
-    'application/mdb': ('ACCESS', 'MS Access Database'),
-    'application/msaccess': ('ACCESS', 'MS Access Database'),
-    'application/x-msaccess': ('ACCESS', 'MS Access Database'),
-    'application/vnd.msaccess': ('ACCESS', 'MS Access Database'),
-    'application/vnd.ms-access': ('ACCESS', 'MS Access Database'),
-
+    "mdb": ("ACCESS", "MS Access Database"),
+    "access": ("ACCESS", "MS Access Database"),
+    "application/mdb": ("ACCESS", "MS Access Database"),
+    "application/msaccess": ("ACCESS", "MS Access Database"),
+    "application/x-msaccess": ("ACCESS", "MS Access Database"),
+    "application/vnd.msaccess": ("ACCESS", "MS Access Database"),
+    "application/vnd.ms-access": ("ACCESS", "MS Access Database"),
     # MS Excel File Types
-    'xl': ('EXCEL', 'MS Excel File'),
-    'xla': ('EXCEL', 'MS Excel File'),
-    'xlb': ('EXCEL', 'MS Excel File'),
-    'xlc': ('EXCEL', 'MS Excel File'),
-    'xld': ('EXCEL', 'MS Excel File'),
-    'xls': ('EXCEL', 'MS Excel File'),
-    'xlsx': ('EXCEL', 'MS Excel File'),
-    'xlsm': ('EXCEL', 'MS Excel File'),
-    'excel': ('EXCEL', 'MS Excel File'),
-    'openXML': ('EXCEL', 'MS Excel File'),
-    'application/excel': ('EXCEL', 'MS Excel File'),
-    'application/x-excel': ('EXCEL', 'MS Excel File'),
-    'application/x-msexcel': ('EXCEL', 'MS Excel File'),
-    'application/vnd.ms-excel': ('EXCEL', 'MS Excel File'),
-    'application/vnd.ms-excel.sheet.macroEnabled.12': ('EXCEL', 'MS Excel File'),
-    'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet': ('EXCEL', 'MS Excel File'),
-
+    "xl": ("EXCEL", "MS Excel File"),
+    "xla": ("EXCEL", "MS Excel File"),
+    "xlb": ("EXCEL", "MS Excel File"),
+    "xlc": ("EXCEL", "MS Excel File"),
+    "xld": ("EXCEL", "MS Excel File"),
+    "xls": ("EXCEL", "MS Excel File"),
+    "xlsx": ("EXCEL", "MS Excel File"),
+    "xlsm": ("EXCEL", "MS Excel File"),
+    "excel": ("EXCEL", "MS Excel File"),
+    "openXML": ("EXCEL", "MS Excel File"),
+    "application/excel": ("EXCEL", "MS Excel File"),
+    "application/x-excel": ("EXCEL", "MS Excel File"),
+    "application/x-msexcel": ("EXCEL", "MS Excel File"),
+    "application/vnd.ms-excel": ("EXCEL", "MS Excel File"),
+    "application/vnd.ms-excel.sheet.macroEnabled.12": ("EXCEL", "MS Excel File"),
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": (
+        "EXCEL",
+        "MS Excel File",
+    ),
     # MS PowerPoint File Types
-    'ppt': ('POWERPOINT', 'MS PowerPoint File'),
-    'pps': ('POWERPOINT', 'MS PowerPoint File'),
-    'pptx': ('POWERPOINT', 'MS PowerPoint File'),
-    'ppsx': ('POWERPOINT', 'MS PowerPoint File'),
-    'pptm': ('POWERPOINT', 'MS PowerPoint File'),
-    'ppsm': ('POWERPOINT', 'MS PowerPoint File'),
-    'sldx': ('POWERPOINT', 'MS PowerPoint File'),
-    'sldm': ('POWERPOINT', 'MS PowerPoint File'),
-    'application/powerpoint': ('POWERPOINT', 'MS PowerPoint File'),
-    'application/mspowerpoint': ('POWERPOINT', 'MS PowerPoint File'),
-    'application/x-mspowerpoint': ('POWERPOINT', 'MS PowerPoint File'),
-    'application/vnd.ms-powerpoint': ('POWERPOINT', 'MS PowerPoint File'),
-    'application/vnd.ms-powerpoint.presentation.macroEnabled.12': ('POWERPOINT', 'MS PowerPoint File'),
-    'application/vnd.ms-powerpoint.slideshow.macroEnabled.12': ('POWERPOINT', 'MS PowerPoint File'),
-    'application/vnd.ms-powerpoint.slide.macroEnabled.12': ('POWERPOINT', 'MS PowerPoint File'),
-    'application/vnd.openxmlformats-officedocument.presentationml.slide': ('POWERPOINT', 'MS PowerPoint File'),
-    'application/vnd.openxmlformats-officedocument.presentationml.presentation': ('POWERPOINT', 'MS PowerPoint File'),
-    'application/vnd.openxmlformats-officedocument.presentationml.slideshow': ('POWERPOINT', 'MS PowerPoint File'),
-
+    "ppt": ("POWERPOINT", "MS PowerPoint File"),
+    "pps": ("POWERPOINT", "MS PowerPoint File"),
+    "pptx": ("POWERPOINT", "MS PowerPoint File"),
+    "ppsx": ("POWERPOINT", "MS PowerPoint File"),
+    "pptm": ("POWERPOINT", "MS PowerPoint File"),
+    "ppsm": ("POWERPOINT", "MS PowerPoint File"),
+    "sldx": ("POWERPOINT", "MS PowerPoint File"),
+    "sldm": ("POWERPOINT", "MS PowerPoint File"),
+    "application/powerpoint": ("POWERPOINT", "MS PowerPoint File"),
+    "application/mspowerpoint": ("POWERPOINT", "MS PowerPoint File"),
+    "application/x-mspowerpoint": ("POWERPOINT", "MS PowerPoint File"),
+    "application/vnd.ms-powerpoint": ("POWERPOINT", "MS PowerPoint File"),
+    "application/vnd.ms-powerpoint.presentation.macroEnabled.12": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    "application/vnd.ms-powerpoint.slideshow.macroEnabled.12": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    "application/vnd.ms-powerpoint.slide.macroEnabled.12": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    "application/vnd.openxmlformats-officedocument.presentationml.slide": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
+    "application/vnd.openxmlformats-officedocument.presentationml.slideshow": (
+        "POWERPOINT",
+        "MS PowerPoint File",
+    ),
     # MS Word File Types
-    'doc': ('DOC', 'MS Word File'),
-    'docx': ('DOC', 'MS Word File'),
-    'docm': ('DOC', 'MS Word File'),
-    'word': ('DOC', 'MS Word File'),
-    'application/msword': ('DOC', 'MS Word File'),
-    'application/vnd.ms-word.document.macroEnabled.12': ('DOC', 'MS Word File'),
-    'application/vnd.openxmlformats-officedocument.wordprocessingml.document': ('DOC', 'MS Word File'),
-
+    "doc": ("DOC", "MS Word File"),
+    "docx": ("DOC", "MS Word File"),
+    "docm": ("DOC", "MS Word File"),
+    "word": ("DOC", "MS Word File"),
+    "application/msword": ("DOC", "MS Word File"),
+    "application/vnd.ms-word.document.macroEnabled.12": ("DOC", "MS Word File"),
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document": (
+        "DOC",
+        "MS Word File",
+    ),
     # Network Common Data Form (NetCDF) File Types
-    'nc': ('CDF', 'NetCDF File'),
-    'cdf': ('CDF', 'NetCDF File'),
-    'netcdf': ('CDF', 'NetCDF File'),
-    'application/x-netcdf': ('NETCDF', 'NetCDF File'),
-
+    "nc": ("CDF", "NetCDF File"),
+    "cdf": ("CDF", "NetCDF File"),
+    "netcdf": ("CDF", "NetCDF File"),
+    "application/x-netcdf": ("NETCDF", "NetCDF File"),
     # PDF File Types
-    'pdf': ('PDF', 'PDF File'),
-    'application/pdf': ('PDF', 'PDF File'),
-
+    "pdf": ("PDF", "PDF File"),
+    "application/pdf": ("PDF", "PDF File"),
     # PERL File Types
-    'pl': ('PERL', 'Perl Script File'),
-    'pm': ('PERL', 'Perl Module File'),
-    'perl': ('PERL', 'Perl Script File'),
-    'text/x-perl': ('PERL', 'Perl Script File'),
-
+    "pl": ("PERL", "Perl Script File"),
+    "pm": ("PERL", "Perl Module File"),
+    "perl": ("PERL", "Perl Script File"),
+    "text/x-perl": ("PERL", "Perl Script File"),
     # QGIS File Types
-    'qgis': ('QGIS', 'QGIS File'),
-    'application/x-qgis': ('QGIS', 'QGIS File'),
-
+    "qgis": ("QGIS", "QGIS File"),
+    "application/x-qgis": ("QGIS", "QGIS File"),
     # RAR File Types
-    'rar': ('RAR', 'RAR Compressed File'),
-    'application/rar': ('RAR', 'RAR Compressed File'),
-    'application/vnd.rar': ('RAR', 'RAR Compressed File'),
-    'application/x-rar-compressed': ('RAR', 'RAR Compressed File'),
-
+    "rar": ("RAR", "RAR Compressed File"),
+    "application/rar": ("RAR", "RAR Compressed File"),
+    "application/vnd.rar": ("RAR", "RAR Compressed File"),
+    "application/x-rar-compressed": ("RAR", "RAR Compressed File"),
     # Resource Description Framework (RDF) File Types
-    'rdf': ('RDF', 'RDF File'),
-    'application/rdf+xml': ('RDF', 'RDF File'),
-
+    "rdf": ("RDF", "RDF File"),
+    "application/rdf+xml": ("RDF", "RDF File"),
     # Rich Text Format (RTF) File Types
-    'rt': ('RICH TEXT', 'Rich Text File'),
-    'rtf': ('RICH TEXT', 'Rich Text File'),
-    'rtx': ('RICH TEXT', 'Rich Text File'),
-    'text/richtext': ('RICH TEXT', 'Rich Text File'),
-    'text/vnd.rn-realtext': ('RICH TEXT', 'Rich Text File'),
-    'application/rtf': ('RICH TEXT', 'Rich Text File'),
-    'application/x-rtf': ('RICH TEXT', 'Rich Text File'),
-
+    "rt": ("RICH TEXT", "Rich Text File"),
+    "rtf": ("RICH TEXT", "Rich Text File"),
+    "rtx": ("RICH TEXT", "Rich Text File"),
+    "text/richtext": ("RICH TEXT", "Rich Text File"),
+    "text/vnd.rn-realtext": ("RICH TEXT", "Rich Text File"),
+    "application/rtf": ("RICH TEXT", "Rich Text File"),
+    "application/x-rtf": ("RICH TEXT", "Rich Text File"),
     # SID File Types - Primary association: Commodore64 (C64)?
-    'sid': ('SID', 'SID File'),
-    'mrsid': ('SID', 'SID File'),
-    'audio/psid': ('SID', 'SID File'),
-    'audio/x-psid': ('SID', 'SID File'),
-    'audio/sidtune': ('SID', 'MID File'),
-    'audio/x-sidtune': ('SID', 'SID File'),
-    'audio/prs.sid': ('SID', 'SID File'),
-
+    "sid": ("SID", "SID File"),
+    "mrsid": ("SID", "SID File"),
+    "audio/psid": ("SID", "SID File"),
+    "audio/x-psid": ("SID", "SID File"),
+    "audio/sidtune": ("SID", "MID File"),
+    "audio/x-sidtune": ("SID", "SID File"),
+    "audio/prs.sid": ("SID", "SID File"),
     # Tab Separated Values (TSV) File Types
-    'tsv': ('TSV', 'Tab Separated Values File'),
-    'text/tab-separated-values': ('TSV', 'Tab Separated Values File'),
-
+    "tsv": ("TSV", "Tab Separated Values File"),
+    "text/tab-separated-values": ("TSV", "Tab Separated Values File"),
     # Tape Archive (TAR) File Types
-    'tar': ('TAR', 'TAR Compressed File'),
-    'application/x-tar': ('TAR', 'TAR Compressed File'),
-
+    "tar": ("TAR", "TAR Compressed File"),
+    "application/x-tar": ("TAR", "TAR Compressed File"),
     # Text File Types
-    'txt': ('TEXT', 'Text File'),
-    'text/plain': ('TEXT', 'Text File'),
-
+    "txt": ("TEXT", "Text File"),
+    "text/plain": ("TEXT", "Text File"),
     # Extensible Markup Language (XML) File Types
-    'xml': ('XML', 'XML File'),
-    'text/xml': ('XML', 'XML File'),
-    'application/xml': ('XML', 'XML File'),
-
+    "xml": ("XML", "XML File"),
+    "text/xml": ("XML", "XML File"),
+    "application/xml": ("XML", "XML File"),
     # XYZ File Format File Types
-    'xyz': ('XYZ', 'XYZ File'),
-    'chemical/x-xyz': ('XYZ', 'XYZ File'),
-
+    "xyz": ("XYZ", "XYZ File"),
+    "chemical/x-xyz": ("XYZ", "XYZ File"),
     # ZIP File Types
-    'zip': ('ZIP', 'Zip File'),
-    'application/zip': ('ZIP', 'Zip File'),
-    'multipart/x-zip': ('ZIP', 'Zip File'),
-    'application/x-compressed': ('ZIP', 'Zip File'),
-    'application/x-zip-compressed': ('ZIP', 'Zip File'),
+    "zip": ("ZIP", "Zip File"),
+    "application/zip": ("ZIP", "Zip File"),
+    "multipart/x-zip": ("ZIP", "Zip File"),
+    "application/x-compressed": ("ZIP", "Zip File"),
+    "application/x-zip-compressed": ("ZIP", "Zip File"),
 }
 
 
 def api_doc_url():
     lang = h.lang()
-    ckan_major_minor_version = '.'.join(h.ckan_version().split('.')[0:2])
+    ckan_major_minor_version = ".".join(h.ckan_version().split(".")[0:2])
 
-    return 'https://docs.ckan.org/{lang}/{version}/api/index.html'.format(
-           lang=lang, version=ckan_major_minor_version)
+    return "https://docs.ckan.org/{lang}/{version}/api/index.html".format(
+        lang=lang, version=ckan_major_minor_version
+    )
 
 
 def render_datetime_datagov(date_str):
@@ -264,101 +259,103 @@ def render_datetime_datagov(date_str):
 
 def get_harvest_object_formats(harvest_object_id, dataset_is_datajson=False):
     # simplified return for harvest_next
-    harvest_next = asbool(config.get('ckanext.datagovtheme.harvest_next', 'false'))
+    harvest_next = asbool(config.get("ckanext.datagovtheme.harvest_next", "false"))
     if harvest_next:
-        return {
-            'object_format': 'data.json' if dataset_is_datajson else 'ISO-19139'
-        }
+        return {"object_format": "data.json" if dataset_is_datajson else "ISO-19139"}
 
     try:
-        obj = p.toolkit.get_action('harvest_object_show')({}, {'id': harvest_object_id})
+        obj = p.toolkit.get_action("harvest_object_show")({}, {"id": harvest_object_id})
     except p.toolkit.ObjectNotFound:
-        log.info('Harvest object not found {0}:'.format(harvest_object_id))
+        log.info("Harvest object not found {0}:".format(harvest_object_id))
         return {}
 
     def get_extra(obj, key, default=None):
-        for k, v in obj['extras'].items():
+        for k, v in obj["extras"].items():
             if k == key:
                 return v
         return default
 
     def format_title(format_name):
         format_titles = {
-            'iso': 'ISO-19139',
-            'fgdc': 'FGDC',
-            'arcgis_json': 'ArcGIS JSON',
-            'ckan': 'CKAN'
+            "iso": "ISO-19139",
+            "fgdc": "FGDC",
+            "arcgis_json": "ArcGIS JSON",
+            "ckan": "CKAN",
         }
-        return format_titles[format_name] if format_name in format_titles else format_name
+        return (
+            format_titles[format_name] if format_name in format_titles else format_name
+        )
 
     def format_type(format_name):
         if not format_name:
-            return ''
+            return ""
 
-        if format_name in ('iso', 'fgdc'):
-            format_type = 'xml'
-        elif format_name in ('arcgis'):
-            format_type = 'json'
-        elif format_name in ('ckan'):
-            format_type = 'ckan'
+        if format_name in ("iso", "fgdc"):
+            format_type = "xml"
+        elif format_name in ("arcgis"):
+            format_type = "json"
+        elif format_name in ("ckan"):
+            format_type = "ckan"
         else:
-            format_type = ''
+            format_type = ""
         return format_type
 
-    format_name = get_extra(obj, 'format', 'iso')
-    original_format_name = get_extra(obj, 'original_format')
+    format_name = get_extra(obj, "format", "iso")
+    original_format_name = get_extra(obj, "original_format")
 
     # check if harvest_object holds a ckan_url key
     try:
-        json.loads(obj['content'])['ckan_url']
-        format_name = 'ckan'
+        json.loads(obj["content"])["ckan_url"]
+        format_name = "ckan"
     except Exception:
         pass
 
     return {
-        'object_format': format_title(format_name),
-        'object_format_type': format_type(format_name),
-        'original_format': format_title(original_format_name),
-        'original_format_type': format_type(original_format_name),
+        "object_format": format_title(format_name),
+        "object_format_type": format_type(format_name),
+        "original_format": format_title(original_format_name),
+        "original_format_type": format_type(original_format_name),
     }
 
 
-def get_harvest_source_link(package_dict, type='source'):
-    harvest_source_id = get_pkg_dict_extra(package_dict, 'harvest_source_id', None)
-    harvest_source_title = get_pkg_dict_extra(package_dict, 'harvest_source_title', None)
-    harvest_object_id = get_pkg_dict_extra(package_dict, 'harvest_object_id', None)
-    harvest_admin_url = config.get('ckanext.datagovtheme.harvest_admin_url')
+def get_harvest_source_link(package_dict, type="source"):
+    harvest_source_id = get_pkg_dict_extra(package_dict, "harvest_source_id", None)
+    harvest_source_title = get_pkg_dict_extra(
+        package_dict, "harvest_source_title", None
+    )
+    harvest_object_id = get_pkg_dict_extra(package_dict, "harvest_object_id", None)
+    harvest_admin_url = config.get("ckanext.datagovtheme.harvest_admin_url")
 
     if harvest_source_id and harvest_source_title:
-        if type == 'metadata':
+        if type == "metadata":
             url = f"{harvest_admin_url}/harvest_record/{harvest_object_id}/raw"
         else:
             url = f"{harvest_admin_url}/harvest_source/{harvest_source_id}"
         return p.toolkit.literal(url)
 
-    return ''
+    return ""
 
 
 # https://github.com/ckan/ckanext-spatial/blob/011008b9c5c4bf58ddd401c805328a9928bbe4ea/ckanext/spatial/helpers.py
 def get_reference_date(date_str):
-    '''
-        Gets a reference date extra created by the harvesters and formats it
-        nicely for the UI.
-        Examples:
-            [{"type": "creation", "value": "1977"}, {"type": "revision", "value": "1981-05-15"}]
-            [{"type": "publication", "value": "1977"}]
-            [{"type": "publication", "value": "NaN-NaN-NaN"}]
-        Results
-            1977 (creation), May 15, 1981 (revision)
-            1977 (publication)
-            NaN-NaN-NaN (publication)
-    '''
+    """
+    Gets a reference date extra created by the harvesters and formats it
+    nicely for the UI.
+    Examples:
+        [{"type": "creation", "value": "1977"}, {"type": "revision", "value": "1981-05-15"}]
+        [{"type": "publication", "value": "1977"}]
+        [{"type": "publication", "value": "NaN-NaN-NaN"}]
+    Results
+        1977 (creation), May 15, 1981 (revision)
+        1977 (publication)
+        NaN-NaN-NaN (publication)
+    """
     try:
         out = []
         for date in h.json.loads(date_str):
-            value = h.render_datetime(date['value']) or date['value']
-            out.append('{0} ({1})'.format(value, date['type']))
-        return ', '.join(out)
+            value = h.render_datetime(date["value"]) or date["value"]
+            out.append("{0} ({1})".format(value, date["type"]))
+        return ", ".join(out)
     except (ValueError, TypeError):
         return date_str
 
@@ -366,83 +363,124 @@ def get_reference_date(date_str):
 # https://github.com/ckan/ckanext-spatial/blob/011008b9c5c4bf58ddd401c805328a9928bbe4ea/ckanext/spatial/helpers.py#L35
 # This doesn't seem specific to ckanext-spatial. Maybe this should move into ckanext-harvest or ckan proper?
 def get_responsible_party(value):
-    '''
-        Gets a responsible party extra created by the harvesters and formats it
-        nicely for the UI.
-        Examples:
-            [{"name": "Complex Systems Research Center", "roles": ["pointOfContact"]}]
-            [
-                {"name": "British Geological Survey", "roles": ["custodian", "pointOfContact"]},
-                {"name": "Natural England", "roles": ["publisher"]}
-            ]
-        Results
-            Complex Systems Research Center (pointOfContact)
-            British Geological Survey (custodian, pointOfContact); Natural England (publisher)
-    '''
+    """
+    Gets a responsible party extra created by the harvesters and formats it
+    nicely for the UI.
+    Examples:
+        [{"name": "Complex Systems Research Center", "roles": ["pointOfContact"]}]
+        [
+            {"name": "British Geological Survey", "roles": ["custodian", "pointOfContact"]},
+            {"name": "Natural England", "roles": ["publisher"]}
+        ]
+    Results
+        Complex Systems Research Center (pointOfContact)
+        British Geological Survey (custodian, pointOfContact); Natural England (publisher)
+    """
     formatted = {
-        'resourceProvider': p.toolkit._('Resource Provider'),
-        'pointOfContact': p.toolkit._('Point of Contact'),
-        'principalInvestigator': p.toolkit._('Principal Investigator'),
+        "resourceProvider": p.toolkit._("Resource Provider"),
+        "pointOfContact": p.toolkit._("Point of Contact"),
+        "principalInvestigator": p.toolkit._("Principal Investigator"),
     }
 
     try:
         out = []
         parties = h.json.loads(value)
         for party in parties:
-            roles = [formatted[role] if role in list(formatted.keys()) else p.toolkit._(role.capitalize()) for role in
-                     party['roles']]
-            out.append('{0} ({1})'.format(party['name'], ', '.join(roles)))
-        return '; '.join(out)
+            roles = [
+                (
+                    formatted[role]
+                    if role in list(formatted.keys())
+                    else p.toolkit._(role.capitalize())
+                )
+                for role in party["roles"]
+            ]
+            out.append("{0} ({1})".format(party["name"], ", ".join(roles)))
+        return "; ".join(out)
     except (ValueError, TypeError):
         return value
 
 
 def is_map_viewer_format(resource):
     # TODO rename config option to ckanext.datagovtheme
-    viewer_url = config.get('ckanext.geodatagov.spatial_preview.url')
-    viewer_formats = config.get('ckanext.geodatagov.spatial_preview.formats', 'wms kml kmz').strip().split(' ')
+    viewer_url = config.get("ckanext.geodatagov.spatial_preview.url")
+    viewer_formats = (
+        config.get("ckanext.geodatagov.spatial_preview.formats", "wms kml kmz")
+        .strip()
+        .split(" ")
+    )
 
-    return viewer_url and resource.get('url') and resource.get('format', '').lower() in viewer_formats
+    return (
+        viewer_url
+        and resource.get("url")
+        and resource.get("format", "").lower() in viewer_formats
+    )
 
 
 def get_map_viewer_params(resource, advanced=False):
 
     params = {
-        'url': resource['url'],
-        'serviceType': resource.get('format'),
+        "url": resource["url"],
+        "serviceType": resource.get("format"),
     }
-    if resource.get('default_srs'):
-        params['srs'] = resource['default_srs']
+    if resource.get("default_srs"):
+        params["srs"] = resource["default_srs"]
 
     if advanced:
-        params['mode'] == 'advanced'
+        params["mode"] == "advanced"
 
     return urllib.parse.urlencode(params)
 
 
 types = {
-    'web': ('html', 'data', 'esri rest', 'gov', 'org', ''),
-    'preview': ('csv', 'xls', 'txt', 'jpg', 'jpeg', 'png', 'gif'),
+    "web": ("html", "data", "esri rest", "gov", "org", ""),
+    "preview": ("csv", "xls", "txt", "jpg", "jpeg", "png", "gif"),
     # "web map application" is deprecated in favour of "arcgis online map"
-    'map': ('wms', 'kml', 'kmz', 'georss', 'web map application', 'arcgis online map'),
-    'plotly': ('csv', 'xls', 'excel', 'openxml', 'access', 'application/vnd.ms-excel',
-               'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-               'text/csv', 'text/tab-separated-values',
-               'application/matlab-mattext/x-matlab', 'application/x-msaccess',
-               'application/msaccess', 'application/x-hdf', 'application/x-bag'),
-    'cartodb': ('csv', 'xls', 'excel', 'openxml', 'kml', 'geojson', 'application/vnd.ms-excel',
-                'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-                'text/csv', 'application/vnd.google-earth.kml+xml',
-                'application/vnd.geo+json'),
-    'arcgis': ('esri rest', 'wms', 'kml', 'kmz', 'application/vnd.google-earth.kml+xml', 'georss')
+    "map": ("wms", "kml", "kmz", "georss", "web map application", "arcgis online map"),
+    "plotly": (
+        "csv",
+        "xls",
+        "excel",
+        "openxml",
+        "access",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "text/csv",
+        "text/tab-separated-values",
+        "application/matlab-mattext/x-matlab",
+        "application/x-msaccess",
+        "application/msaccess",
+        "application/x-hdf",
+        "application/x-bag",
+    ),
+    "cartodb": (
+        "csv",
+        "xls",
+        "excel",
+        "openxml",
+        "kml",
+        "geojson",
+        "application/vnd.ms-excel",
+        "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "text/csv",
+        "application/vnd.google-earth.kml+xml",
+        "application/vnd.geo+json",
+    ),
+    "arcgis": (
+        "esri rest",
+        "wms",
+        "kml",
+        "kmz",
+        "application/vnd.google-earth.kml+xml",
+        "georss",
+    ),
 }
 
 
 def is_type_format(type, resource):
     if resource and type in types:
-        format = resource.get('format', 'data').lower()
+        format = resource.get("format", "data").lower()
         # TODO: convert mimetypes to formats so we dont have to do this.
-        mimetype = resource.get('mimetype')
+        mimetype = resource.get("mimetype")
         if mimetype:
             mimetype = mimetype.lower()
         if format in types[type] or mimetype in types[type]:
@@ -451,34 +489,34 @@ def is_type_format(type, resource):
 
 
 def is_web_format(resource):
-    return is_type_format('web', resource)
+    return is_type_format("web", resource)
 
 
 def is_preview_format(resource):
-    return is_type_format('preview', resource)
+    return is_type_format("preview", resource)
 
 
 def is_map_format(resource):
-    return is_type_format('map', resource)
+    return is_type_format("map", resource)
 
 
 def is_plotly_format(resource):
-    return is_type_format('plotly', resource)
+    return is_type_format("plotly", resource)
 
 
 def is_cartodb_format(resource):
-    return is_type_format('cartodb', resource)
+    return is_type_format("cartodb", resource)
 
 
 def is_arcgis_format(resource):
-    return is_type_format('arcgis', resource)
+    return is_type_format("arcgis", resource)
 
 
 def arcgis_format_query(resource):
-    mimetype = resource.get('mimetype', None)
-    kmlstring = re.compile('(kml|kmz)')
+    mimetype = resource.get("mimetype", None)
+    kmlstring = re.compile("(kml|kmz)")
     if kmlstring.match(str(mimetype)):
-        return 'kml'
+        return "kml"
     else:
         # wms, georss
         return mimetype
@@ -491,7 +529,7 @@ def convert_resource_format(format):
     if format in formats:
         format = RESOURCE_MAPPING[format][1]
     else:
-        format = 'Web Resource'
+        format = "Web Resource"
 
     return format
 
@@ -499,6 +537,7 @@ def convert_resource_format(format):
 def remove_extra_chars(str_value):
     # this will remove brackets for list and dict values.
     import ast
+
     new_value = None
 
     try:
@@ -508,9 +547,11 @@ def remove_extra_chars(str_value):
 
     if type(new_value) is list:
         new_value = [i.strip() for i in new_value]
-        ret = ', '.join(new_value)
+        ret = ", ".join(new_value)
     elif type(new_value) is dict:
-        ret = ', '.join('{0}:{1}'.format(key, val) for key, val in list(new_value.items()))
+        ret = ", ".join(
+            "{0}:{1}".format(key, val) for key, val in list(new_value.items())
+        )
     else:
         ret = str_value
 
@@ -519,27 +560,26 @@ def remove_extra_chars(str_value):
 
 def schema11_key_mod(key):
     key_map = {
-        'Catalog @Context': 'Metadata Context',
-        'Catalog @Id': 'Metadata Catalog ID',
-        'Catalog Conformsto': 'Schema Version',
-        'Catalog DescribedBy': 'Data Dictionary',
-
+        "Catalog @Context": "Metadata Context",
+        "Catalog @Id": "Metadata Catalog ID",
+        "Catalog Conformsto": "Schema Version",
+        "Catalog DescribedBy": "Data Dictionary",
         # 'Identifier': 'Unique Identifier',
-        'Modified': 'Data Last Modified',
-        'Accesslevel': 'Public Access Level',
-        'Bureaucode': 'Bureau Code',
-        'Programcode': 'Program Code',
-        'Accrualperiodicity': 'Data Update Frequency',
-        'Conformsto': 'Data Standard',
-        'Dataquality': 'Data Quality',
-        'Describedby': 'Data Dictionary',
-        'Describedbytype': 'Data Dictionary Type',
-        'Issued': 'Data First Published',
-        'Landingpage': 'Homepage URL',
-        'Primaryitinvestmentuii': 'Primary IT Investment UII',
-        'References': 'Related Documents',
-        'Systemofrecords': 'System of Records',
-        'Theme': 'Category',
+        "Modified": "Data Last Modified",
+        "Accesslevel": "Public Access Level",
+        "Bureaucode": "Bureau Code",
+        "Programcode": "Program Code",
+        "Accrualperiodicity": "Data Update Frequency",
+        "Conformsto": "Data Standard",
+        "Dataquality": "Data Quality",
+        "Describedby": "Data Dictionary",
+        "Describedbytype": "Data Dictionary Type",
+        "Issued": "Data First Published",
+        "Landingpage": "Homepage URL",
+        "Primaryitinvestmentuii": "Primary IT Investment UII",
+        "References": "Related Documents",
+        "Systemofrecords": "System of Records",
+        "Theme": "Category",
     }
 
     return key_map.get(key, key)
@@ -547,31 +587,32 @@ def schema11_key_mod(key):
 
 def schema11_frequency_mod(value):
     frequency_map = {
-        'R/P10Y': 'Decennial',
-        'R/P4Y': 'Quadrennial',
-        'R/P1Y': 'Annual',
-        'R/P2M': 'Bimonthly',
-        'R/P0.5M': 'Bimonthly',
-        'R/P3.5D': 'Semiweekly',
-        'R/P1D': 'Daily',
-        'R/P2W': 'Biweekly',
-        'R/P0.5W': 'Biweekly',
-        'R/P6M': 'Semiannual',
-        'R/P2Y': 'Biennial',
-        'R/P3Y': 'Triennial',
-        'R/P0.33W': 'Three times a week',
-        'R/P0.33M': 'Three times a month',
-        'R/PT1S': 'Continuously updated',
-        'R/P1M': 'Monthly',
-        'R/P3M': 'Quarterly',
-        'R/P4M': 'Three times a year',
-        'R/P1W': 'Weekly',
+        "R/P10Y": "Decennial",
+        "R/P4Y": "Quadrennial",
+        "R/P1Y": "Annual",
+        "R/P2M": "Bimonthly",
+        "R/P0.5M": "Bimonthly",
+        "R/P3.5D": "Semiweekly",
+        "R/P1D": "Daily",
+        "R/P2W": "Biweekly",
+        "R/P0.5W": "Biweekly",
+        "R/P6M": "Semiannual",
+        "R/P2Y": "Biennial",
+        "R/P3Y": "Triennial",
+        "R/P0.33W": "Three times a week",
+        "R/P0.33M": "Three times a month",
+        "R/PT1S": "Continuously updated",
+        "R/P1M": "Monthly",
+        "R/P3M": "Quarterly",
+        "R/P4M": "Three times a year",
+        "R/P1W": "Weekly",
     }
     return frequency_map.get(value, value)
 
 
 def convert_top_category_to_list(str_value):
     import ast
+
     list_value = None
 
     try:
@@ -597,26 +638,28 @@ def get_bureau_info(bureau_code):
     if not bureau_code:
         return None
 
-    WEB_PATH = '/images/logos/'
-    LOCAL_PATH = 'fanstatic_library/images/logos/'
+    WEB_PATH = "/images/logos/"
+    LOCAL_PATH = "fanstatic_library/images/logos/"
 
     # handle both '007:15', or ['007:15', '007:16']
     if isinstance(bureau_code, list):
         bureau_code = bureau_code[0]
 
     try:
-        agency_part, bureau_part = bureau_code.split(':')
+        agency_part, bureau_part = bureau_code.split(":")
     except ValueError:
-        log.warning('bureau code is invalid code=%s' % bureau_code)
+        log.warning("bureau code is invalid code=%s" % bureau_code)
         return None
 
-    controller = 'dataset'
+    controller = "dataset"
 
     # TODO in python 3, replace pkg_resources with [importlib-resources](https://pypi.org/project/importlib-resources/)
-    bureau_filename = pkg_resources.resource_filename('ckanext.datagovtheme.data', 'omb_bureau_codes.csv')
+    bureau_filename = pkg_resources.resource_filename(
+        "ckanext.datagovtheme.data", "omb_bureau_codes.csv"
+    )
 
     # Python 3 csv.reader wants text data
-    bureau_file = open(bureau_filename, 'r', newline='', encoding='utf8')
+    bureau_file = open(bureau_filename, "r", newline="", encoding="utf8")
 
     # Should this be cached in memory as an index to speed things up?
     bureau_table = csv.reader(bureau_file)
@@ -626,10 +669,14 @@ def get_bureau_info(bureau_code):
         # repository.
         if agency_part == row[2].zfill(3) and bureau_part == row[3].zfill(2):
             bureau_title = row[1]
-            bureau_url = h.url_for(controller=controller, action='search', q='bureauCode:"%s"' % bureau_code)
+            bureau_url = h.url_for(
+                controller=controller,
+                action="search",
+                q='bureauCode:"%s"' % bureau_code,
+            )
             break
     else:
-        log.warning('omb_bureau_codes.csv is empty')
+        log.warning("omb_bureau_codes.csv is empty")
         return None
 
     # TODO in python 3, use a context manager since we won't need the conditional `open`
@@ -638,28 +685,30 @@ def get_bureau_info(bureau_code):
     # check logo image file exists or not
     # should this be cached as in index to speed this up?
     bureau_logo = None
-    for ext in ['png', 'gif', 'jpg']:
-        logo_filename = '%s-%s.%s' % (agency_part, bureau_part, ext)
+    for ext in ["png", "gif", "jpg"]:
+        logo_filename = "%s-%s.%s" % (agency_part, bureau_part, ext)
         # We should probably be using pre_resources here, too, but we also need
         # to add the logos as assets. That seems to be magically working right
         # now?
-        if os.path.isfile(os.path.join(os.path.dirname(__file__), LOCAL_PATH) + logo_filename):
+        if os.path.isfile(
+            os.path.join(os.path.dirname(__file__), LOCAL_PATH) + logo_filename
+        ):
             bureau_logo = h.url_for_static(WEB_PATH + logo_filename)
             break
 
     return {
-        'title': bureau_title,
-        'code': bureau_code,
-        'logo': bureau_logo,
-        'url': bureau_url,
+        "title": bureau_title,
+        "code": bureau_code,
+        "logo": bureau_logo,
+        "url": bureau_url,
     }
 
 
 # returns true if the package contains a tag with the name 'ngda
 def is_tagged_ngda(pkg_dict):
-    if 'tags' in pkg_dict:
-        for tag in pkg_dict['tags']:
-            if tag['name'].lower() == 'ngda':
+    if "tags" in pkg_dict:
+        for tag in pkg_dict["tags"]:
+            if tag["name"].lower() == "ngda":
                 return True
     return False
 
@@ -682,15 +731,15 @@ def get_collection_packages(pkgs):
     """
     # use a named tuple to store the package id, harvest_source_id, and identifier,
     # so that we don't have to repeat the iteration over these packages again and again
-    PkgTuple = namedtuple('PkgTuple', ['id', 'sid', 'pid'])
+    PkgTuple = namedtuple("PkgTuple", ["id", "sid", "pid"])
     pkgs_tuple = []
     id_query = []
 
     for pkg in pkgs:
-        sid = get_pkg_dict_extra(pkg, 'harvest_source_id', None)
-        pid = get_pkg_dict_extra(pkg, 'identifier', None)
+        sid = get_pkg_dict_extra(pkg, "harvest_source_id", None)
+        pid = get_pkg_dict_extra(pkg, "identifier", None)
         if sid and pid:
-            pkgs_tuple.append(PkgTuple(pkg['id'], sid, pid))
+            pkgs_tuple.append(PkgTuple(pkg["id"], sid, pid))
             id_query.append(f'(harvest_source_id:{sid} isPartOf:"{pid}")')
 
     if not pkgs_tuple:
@@ -701,18 +750,15 @@ def get_collection_packages(pkgs):
     # &rows=0&facet.field=["isPartOf","harvest_source_id"]
     fq = f'({"OR".join(id_query)}include_collection:true)'
 
-    package_search = logic.get_action('package_search')
+    package_search = logic.get_action("package_search")
     search_params = {
-        'fq': fq,
-        'rows': 0,
-        'facet.field': ['harvest_source_id', 'isPartOf']
+        "fq": fq,
+        "rows": 0,
+        "facet.field": ["harvest_source_id", "isPartOf"],
     }
-    result = package_search(
-        {'ignore_auth': True},
-        search_params
-    )
+    result = package_search({"ignore_auth": True}, search_params)
 
-    if not result['count']:
+    if not result["count"]:
         return []
 
     """"
@@ -748,8 +794,8 @@ def get_collection_packages(pkgs):
     CKAN core does not support facet.pivot, so we have to do this check manually.
     """
 
-    pids = result['facets']['isPartOf']
-    sids = result['facets']['harvest_source_id']
+    pids = result["facets"]["isPartOf"]
+    sids = result["facets"]["harvest_source_id"]
 
     collection_pkgs = [pkg for pkg in pkgs_tuple if pkg.pid in pids and pkg.sid in sids]
 
@@ -763,14 +809,11 @@ def get_collection_packages(pkgs):
         if pkg.pid in pids_in_question:
             # make a solr query to check if this pid is actually a collection
             search_params = {
-                'fq': f'collection_info:"{pkg.sid} {pkg.pid}"',
-                'rows': 0,
+                "fq": f'collection_info:"{pkg.sid} {pkg.pid}"',
+                "rows": 0,
             }
-            base_results = package_search(
-                {'ignore_auth': True},
-                search_params
-            )
-            if not asbool(base_results['count']):
+            base_results = package_search({"ignore_auth": True}, search_params)
+            if not asbool(base_results["count"]):
                 # remove this pkg.id from collection_pkgs
                 collection_pkgs.remove(pkg)
 
@@ -780,7 +823,7 @@ def get_collection_packages(pkgs):
 
 # TODO can we drop this dependency on ckanext-harvest? Can this be moved to ckanext-harvest? geodatagov?
 def get_pkg_dict_extra(pkg_dict, key, default=None):
-    '''Override the CKAN core helper to add rolled up extras
+    """Override the CKAN core helper to add rolled up extras
     Returns the value for the dataset extra with the provided key.
 
     If the key is not found, it returns a default value, which is None by
@@ -789,100 +832,108 @@ def get_pkg_dict_extra(pkg_dict, key, default=None):
     :param pkg_dict: dictized dataset
     :key: extra key to lookup
     :default: default value returned if not found
-    '''
-    extras = pkg_dict['extras'] if 'extras' in pkg_dict else []
+    """
+    extras = pkg_dict["extras"] if "extras" in pkg_dict else []
 
     for extra in extras:
-        if extra['key'] == key:
-            return extra['value']
+        if extra["key"] == key:
+            return extra["value"]
 
     # also include the rolled up extras
     for extra in extras:
-        if 'extras_rollup' == extra.get('key'):
-            rolledup_extras = json.loads(extra.get('value'))
+        if "extras_rollup" == extra.get("key"):
+            rolledup_extras = json.loads(extra.get("value"))
             for k, value in rolledup_extras.items():
                 if k == key:
                     return value
 
-    harvest_next = asbool(config.get('ckanext.datagovtheme.harvest_next', 'false'))
+    harvest_next = asbool(config.get("ckanext.datagovtheme.harvest_next", "false"))
     # Also include harvest information if exists
-    if key in ['harvest_object_id', 'harvest_source_id', 'harvest_source_title'] \
-            and not harvest_next:
+    if (
+        key in ["harvest_object_id", "harvest_source_id", "harvest_source_title"]
+        and not harvest_next
+    ):
 
-        harvest_object = model.Session.query(HarvestObject) \
-                .filter(HarvestObject.package_id == pkg_dict['id']) \
-                .filter(HarvestObject.current == True).first()  # noqa
+        harvest_object = (
+            model.Session.query(HarvestObject)
+            .filter(HarvestObject.package_id == pkg_dict["id"])
+            .filter(HarvestObject.current is True)
+            .first()
+        )  # noqa
 
         if harvest_object:
-            if key == 'harvest_object_id':
+            if key == "harvest_object_id":
                 return harvest_object.id
-            elif key == 'harvest_source_id':
+            elif key == "harvest_source_id":
                 return harvest_object.source.id
-            elif key == 'harvest_source_title':
+            elif key == "harvest_source_title":
                 return harvest_object.source.title
 
     return default
+
 
 # from GSA/ckanext-archiver
 
 
 def archiver_resource_info_table(resource):
-    archival = resource.get('archiver')
+    archival = resource.get("archiver")
     if not archival:
-        return p.toolkit.literal('<!-- No archival info for this resource -->')
-    extra_vars = {'resource': resource}
+        return p.toolkit.literal("<!-- No archival info for this resource -->")
+    extra_vars = {"resource": resource}
     extra_vars.update(archival)
     res = p.toolkit.literal(
-        p.toolkit.render('archiver/resource_info_table.html',
-                         extra_vars=extra_vars)
+        p.toolkit.render("archiver/resource_info_table.html", extra_vars=extra_vars)
     )
     return res
 
 
 def archiver_is_resource_broken_line(resource):
-    archival = resource.get('archiver')
+    archival = resource.get("archiver")
     if not archival:
-        return p.toolkit.literal('<!-- No archival info for this resource -->')
-    extra_vars = {'resource': resource}
+        return p.toolkit.literal("<!-- No archival info for this resource -->")
+    extra_vars = {"resource": resource}
     extra_vars.update(archival)
     res = p.toolkit.literal(
-        p.toolkit.render('archiver/is_resource_broken_line.html',
-                         extra_vars=extra_vars))
+        p.toolkit.render("archiver/is_resource_broken_line.html", extra_vars=extra_vars)
+    )
     return res
+
 
 # from GSA/ckanext-qa
 
 
 def qa_openness_stars_resource_line(resource):
-    qa = resource.get('qa')
+    qa = resource.get("qa")
     if not qa:
-        return p.toolkit.literal('<!-- No qa info for this resource -->')
+        return p.toolkit.literal("<!-- No qa info for this resource -->")
     if not isinstance(qa, dict):
-        return p.toolkit.literal('<!-- QA info was of the wrong type -->')
+        return p.toolkit.literal("<!-- QA info was of the wrong type -->")
     extra_vars = copy.deepcopy(qa)
     return p.toolkit.literal(
-        p.toolkit.render('qa/openness_stars_line.html',
-                         extra_vars=extra_vars))
+        p.toolkit.render("qa/openness_stars_line.html", extra_vars=extra_vars)
+    )
 
 
 def qa_openness_stars_resource_table(resource):
-    qa = resource.get('qa')
+    qa = resource.get("qa")
     if not qa:
-        return p.toolkit.literal('<!-- No qa info for this resource -->')
+        return p.toolkit.literal("<!-- No qa info for this resource -->")
     if not isinstance(qa, dict):
-        return p.toolkit.literal('<!-- QA info was of the wrong type -->')
+        return p.toolkit.literal("<!-- QA info was of the wrong type -->")
     extra_vars = copy.deepcopy(qa)
     return p.toolkit.literal(
-        p.toolkit.render('qa/openness_stars_table.html',
-                         extra_vars=extra_vars))
+        p.toolkit.render("qa/openness_stars_table.html", extra_vars=extra_vars)
+    )
 
 
 def get_login_url():
     # TODO maybe make this a configuration option for ckanext.saml2auth instead of the implicit dependency
     # TODO push this upstream to ckanext.saml2auth, we should be able to use url_for
     # TODO if we have to rely on a config option, it should be in the ckanext.datagovtheme namespace
-    enable_ckan_internal_login = asbool(config.get('ckanext.saml2auth.enable_ckan_internal_login', 'true'))
+    enable_ckan_internal_login = asbool(
+        config.get("ckanext.saml2auth.enable_ckan_internal_login", "true")
+    )
     if enable_ckan_internal_login:
-        return h.url_for(controller='user', action='login')
+        return h.url_for(controller="user", action="login")
 
-    return '/user/saml2login'
+    return "/user/saml2login"

--- a/ckanext/datagovtheme/plugin.py
+++ b/ckanext/datagovtheme/plugin.py
@@ -1,13 +1,13 @@
 import ckan.plugins as p
 from sqlalchemy.util import OrderedDict
 
-p.toolkit.requires_ckan_version("2.9")
-
 from . import blueprint
+
+p.toolkit.requires_ckan_version("2.9")
 
 
 class DatagovTheme(p.SingletonPlugin):
-    '''Theme plugin for catalog.data.gov.'''
+    """Theme plugin for catalog.data.gov."""
 
     # Declare the iterfaces this class implements
     p.implements(p.IBlueprint)
@@ -17,43 +17,49 @@ class DatagovTheme(p.SingletonPlugin):
 
     # IConfigurer
     def update_config(self, config):
-        p.toolkit.add_template_directory(config, 'templates')
-        p.toolkit.add_public_directory(config, 'public')
-        p.toolkit.add_resource('fanstatic_library', 'datagovtheme')
+        p.toolkit.add_template_directory(config, "templates")
+        p.toolkit.add_public_directory(config, "public")
+        p.toolkit.add_resource("fanstatic_library", "datagovtheme")
 
     # IFacets
     def dataset_facets(self, facets_dict, package_type):
 
-        if package_type != 'dataset':
+        if package_type != "dataset":
             return facets_dict
 
-        return OrderedDict([('groups', 'Topics'),
-                            ('vocab_category_all', 'Topic Categories'),
-                            ('metadata_type', 'Dataset Type'),
-                            ('tags', 'Tags'),
-                            ('res_format', 'Formats'),
-                            ('organization_type', 'Organization Types'),
-                            ('organization', 'Organizations'),
-                            ('publisher', 'Publishers'),
-                            ('bureauCode', 'Bureaus'),
-                            # ('extras_progress', 'Progress'),
-                            ])
+        return OrderedDict(
+            [
+                ("groups", "Topics"),
+                ("vocab_category_all", "Topic Categories"),
+                ("metadata_type", "Dataset Type"),
+                ("tags", "Tags"),
+                ("res_format", "Formats"),
+                ("organization_type", "Organization Types"),
+                ("organization", "Organizations"),
+                ("publisher", "Publishers"),
+                ("bureauCode", "Bureaus"),
+                # ('extras_progress', 'Progress'),
+            ]
+        )
 
     def organization_facets(self, facets_dict, organization_type, package_type):
 
         if not package_type:
-            return OrderedDict([('groups', 'Topics'),
-                                ('vocab_category_all', 'Topic Categories'),
-                                ('metadata_type', 'Dataset Type'),
-                                ('tags', 'Tags'),
-                                ('res_format', 'Formats'),
-                                ('groups', 'Topics'),
-                                ('harvest_source_title', 'Harvest Source'),
-                                ('capacity', 'Visibility'),
-                                ('dataset_type', 'Resource Type'),
-                                ('publisher', 'Publishers'),
-                                ('bureauCode', 'Bureaus'),
-                                ])
+            return OrderedDict(
+                [
+                    ("groups", "Topics"),
+                    ("vocab_category_all", "Topic Categories"),
+                    ("metadata_type", "Dataset Type"),
+                    ("tags", "Tags"),
+                    ("res_format", "Formats"),
+                    ("groups", "Topics"),
+                    ("harvest_source_title", "Harvest Source"),
+                    ("capacity", "Visibility"),
+                    ("dataset_type", "Resource Type"),
+                    ("publisher", "Publishers"),
+                    ("bureauCode", "Bureaus"),
+                ]
+            )
         else:
             return facets_dict
 
@@ -61,64 +67,70 @@ class DatagovTheme(p.SingletonPlugin):
 
         # For https://github.com/GSA/datagov-deploy/issues/3630
         # re-evaluate necessity of these two lines after ckan 2.9.6.
-        if organization_type == 'organization':
-            return self.organization_facets(facets_dict, organization_type, package_type)
+        if organization_type == "organization":
+            return self.organization_facets(
+                facets_dict, organization_type, package_type
+            )
 
         # get the categories key
-        group_id = p.toolkit.c.group_dict['id']
-        key = 'vocab___category_tag_%s' % group_id
+        group_id = p.toolkit.c.group_dict["id"]
+        key = "vocab___category_tag_%s" % group_id
         if not package_type:
-            return OrderedDict([(key, 'Categories'),
-                                ('metadata_type', 'Dataset Type'),
-                                ('organization_type', 'Organization Types'),
-                                ('tags', 'Tags'),
-                                ('res_format', 'Formats'),
-                                ('organization', 'Organizations'),
-                                (key, 'Categories'),
-                                # ('publisher', 'Publisher'),
-                                ])
+            return OrderedDict(
+                [
+                    (key, "Categories"),
+                    ("metadata_type", "Dataset Type"),
+                    ("organization_type", "Organization Types"),
+                    ("tags", "Tags"),
+                    ("res_format", "Formats"),
+                    ("organization", "Organizations"),
+                    (key, "Categories"),
+                    # ('publisher', 'Publisher'),
+                ]
+            )
         else:
             return facets_dict
 
     # ITemplateHelpers
     def get_helpers(self):
         from ckanext.datagovtheme import helpers as datagovtheme_helpers
+
         # TODO prefix these helper names with datagovtheme_
         helpers = {
-            'datagovtheme_api_doc_url': datagovtheme_helpers.api_doc_url,
-            'datagovtheme_get_reference_date': datagovtheme_helpers.get_reference_date,
-            'datagovtheme_get_responsible_party': datagovtheme_helpers.get_responsible_party,
-            'is_tagged_ngda': datagovtheme_helpers.is_tagged_ngda,
-            'get_collection_packages': datagovtheme_helpers.get_collection_packages,
-            'render_datetime_datagov': datagovtheme_helpers.render_datetime_datagov,
-            'get_harvest_object_formats': datagovtheme_helpers.get_harvest_object_formats,
-            'get_bureau_info': datagovtheme_helpers.get_bureau_info,
-            'get_harvest_source_link': datagovtheme_helpers.get_harvest_source_link,
-            'is_web_format': datagovtheme_helpers.is_web_format,
-            'is_map_viewer_format': datagovtheme_helpers.is_map_viewer_format,
-            'get_map_viewer_params': datagovtheme_helpers.get_map_viewer_params,
-            'is_preview_format': datagovtheme_helpers.is_preview_format,
-            'is_map_format': datagovtheme_helpers.is_map_format,
-            'is_plotly_format': datagovtheme_helpers.is_plotly_format,
-            'is_cartodb_format': datagovtheme_helpers.is_cartodb_format,
-            'is_arcgis_format': datagovtheme_helpers.is_arcgis_format,
-            'arcgis_format_query': datagovtheme_helpers.arcgis_format_query,
-            'convert_resource_format': datagovtheme_helpers.convert_resource_format,
-            'remove_extra_chars': datagovtheme_helpers.remove_extra_chars,
-            'schema11_key_mod': datagovtheme_helpers.schema11_key_mod,
-            'schema11_frequency_mod': datagovtheme_helpers.schema11_frequency_mod,
-            'convert_top_category_to_list': datagovtheme_helpers.convert_top_category_to_list,
-            'get_pkg_dict_extra': datagovtheme_helpers.get_pkg_dict_extra,
-            'get_login_url': datagovtheme_helpers.get_login_url,
+            "datagovtheme_api_doc_url": datagovtheme_helpers.api_doc_url,
+            "datagovtheme_get_reference_date": datagovtheme_helpers.get_reference_date,
+            "datagovtheme_get_responsible_party": datagovtheme_helpers.get_responsible_party,
+            "is_tagged_ngda": datagovtheme_helpers.is_tagged_ngda,
+            "get_collection_packages": datagovtheme_helpers.get_collection_packages,
+            "render_datetime_datagov": datagovtheme_helpers.render_datetime_datagov,
+            "get_harvest_object_formats": datagovtheme_helpers.get_harvest_object_formats,
+            "get_bureau_info": datagovtheme_helpers.get_bureau_info,
+            "get_harvest_source_link": datagovtheme_helpers.get_harvest_source_link,
+            "is_web_format": datagovtheme_helpers.is_web_format,
+            "is_map_viewer_format": datagovtheme_helpers.is_map_viewer_format,
+            "get_map_viewer_params": datagovtheme_helpers.get_map_viewer_params,
+            "is_preview_format": datagovtheme_helpers.is_preview_format,
+            "is_map_format": datagovtheme_helpers.is_map_format,
+            "is_plotly_format": datagovtheme_helpers.is_plotly_format,
+            "is_cartodb_format": datagovtheme_helpers.is_cartodb_format,
+            "is_arcgis_format": datagovtheme_helpers.is_arcgis_format,
+            "arcgis_format_query": datagovtheme_helpers.arcgis_format_query,
+            "convert_resource_format": datagovtheme_helpers.convert_resource_format,
+            "remove_extra_chars": datagovtheme_helpers.remove_extra_chars,
+            "schema11_key_mod": datagovtheme_helpers.schema11_key_mod,
+            "schema11_frequency_mod": datagovtheme_helpers.schema11_frequency_mod,
+            "convert_top_category_to_list": datagovtheme_helpers.convert_top_category_to_list,
+            "get_pkg_dict_extra": datagovtheme_helpers.get_pkg_dict_extra,
+            "get_login_url": datagovtheme_helpers.get_login_url,
         }
 
         # https://github.com/GSA/ckan/blob/datagov/ckan/config/environment.py#L70:L70
         # Override ckanext-qa and ckanext-archiver template helpers. Is this best practice?
         override_helpers = {
-            'archiver_resource_info_table': datagovtheme_helpers.archiver_resource_info_table,
-            'archiver_is_resource_broken_line': datagovtheme_helpers.archiver_is_resource_broken_line,
-            'qa_openness_stars_resource_line': datagovtheme_helpers.qa_openness_stars_resource_line,
-            'qa_openness_stars_resource_table': datagovtheme_helpers.qa_openness_stars_resource_table,
+            "archiver_resource_info_table": datagovtheme_helpers.archiver_resource_info_table,
+            "archiver_is_resource_broken_line": datagovtheme_helpers.archiver_is_resource_broken_line,
+            "qa_openness_stars_resource_line": datagovtheme_helpers.qa_openness_stars_resource_line,
+            "qa_openness_stars_resource_table": datagovtheme_helpers.qa_openness_stars_resource_table,
         }
 
         helpers.update(override_helpers)

--- a/ckanext/datagovtheme/tests/test_helpers.py
+++ b/ckanext/datagovtheme/tests/test_helpers.py
@@ -2,44 +2,45 @@
 import logging
 import re
 
+import ckan.tests.factories as factories
 import mock
 import pytest
 
 from ckanext.datagovtheme import helpers
-import ckan.tests.factories as factories
-
 
 ################
 # get_login_url
 ################
 
 
-@pytest.mark.ckan_config('ckanext.saml2auth.enable_ckan_internal_login', 'false')
+@pytest.mark.ckan_config("ckanext.saml2auth.enable_ckan_internal_login", "false")
 def test_saml2_login_url():
-    """ test saml2 URL on Catalog-next """
+    """test saml2 URL on Catalog-next"""
     actual_login_url = helpers.get_login_url()
-    assert '/user/saml2login' == actual_login_url
+    assert "/user/saml2login" == actual_login_url
 
 
-@pytest.mark.ckan_config('ckanext.saml2auth.enable_ckan_internal_login', 'true')
+@pytest.mark.ckan_config("ckanext.saml2auth.enable_ckan_internal_login", "true")
 def test_login_url():
-    """ test saml2 URL on Catalog-next """
+    """test saml2 URL on Catalog-next"""
     actual_login_url = helpers.get_login_url()
-    assert '/user/login' == actual_login_url
+    assert "/user/login" == actual_login_url
+
 
 ##############
 # api_doc_url
 ##############
 
 
-@mock.patch('ckanext.datagovtheme.helpers.h')
+@mock.patch("ckanext.datagovtheme.helpers.h")
 def test_api_doc_url(mock_ckan_lib_helpers):
-    mock_ckan_lib_helpers.lang.return_value = 'en'
-    mock_ckan_lib_helpers.ckan_version.return_value = '2.11.2'
+    mock_ckan_lib_helpers.lang.return_value = "en"
+    mock_ckan_lib_helpers.ckan_version.return_value = "2.11.2"
 
     api_doc_url = helpers.api_doc_url()
 
-    assert 'https://docs.ckan.org/en/2.11/api/index.html' == api_doc_url
+    assert "https://docs.ckan.org/en/2.11/api/index.html" == api_doc_url
+
 
 ##################
 # get_bureau_info
@@ -50,67 +51,69 @@ def assert_url(actual_url, expected_bureau_code):
     # In CKAN 2.9, the url_for is returning a path ending in / which does not
     # happen in 2.8. Include an optional ending / in the path, use URL encoded
     # characters.
-    bureau_url_re = re.compile('/dataset/?\\?q=bureauCode:%22(?P<agency_part>[0-9]{3}):(?P<bureau_part>[0-9]{2})%22')
+    bureau_url_re = re.compile(
+        "/dataset/?\\?q=bureauCode:%22(?P<agency_part>[0-9]{3}):(?P<bureau_part>[0-9]{2})%22"
+    )
 
     match = bureau_url_re.match(actual_url)
     assert match, 'URL should match pattern /dataset?q=bureauCode:"000:00"'
 
-    agency_part = match.group('agency_part')
-    bureau_part = match.group('bureau_part')
+    agency_part = match.group("agency_part")
+    bureau_part = match.group("bureau_part")
     assert "%s:%s" % (agency_part, bureau_part) == expected_bureau_code
 
 
 def test_get_bureau_info_blm():
-    bureau_code = '010:04'
+    bureau_code = "010:04"
     bureau_info = helpers.get_bureau_info(bureau_code)
 
-    assert bureau_info['title'] == 'Bureau of Land Management'
-    assert bureau_info['code'] == bureau_code
-    assert bureau_info['logo'] == '/images/logos/010-04.png'
-    assert_url(bureau_info['url'], bureau_code)
+    assert bureau_info["title"] == "Bureau of Land Management"
+    assert bureau_info["code"] == bureau_code
+    assert bureau_info["logo"] == "/images/logos/010-04.png"
+    assert_url(bureau_info["url"], bureau_code)
 
 
 def test_get_bureau_info_logo_jpg():
     """Assert that bureau logos as jpg are found."""
-    bureau_code = '418:00'
+    bureau_code = "418:00"
     bureau_info = helpers.get_bureau_info(bureau_code)
 
-    assert bureau_info['title'] == 'National Endowment for the Humanities'
-    assert bureau_info['code'] == bureau_code
-    assert bureau_info['logo'] == '/images/logos/418-00.jpg'
-    assert_url(bureau_info['url'], bureau_code)
+    assert bureau_info["title"] == "National Endowment for the Humanities"
+    assert bureau_info["code"] == bureau_code
+    assert bureau_info["logo"] == "/images/logos/418-00.jpg"
+    assert_url(bureau_info["url"], bureau_code)
 
 
 def test_get_bureau_info_logo_missing():
     """Assert that bureaus with missing logos are still identified."""
-    bureau_code = '915:00'
+    bureau_code = "915:00"
     bureau_info = helpers.get_bureau_info(bureau_code)
 
-    assert bureau_info['title'] == 'Federal National Mortgage Association'
-    assert bureau_info['code'] == bureau_code
-    assert bureau_info['logo'] is None
-    assert_url(bureau_info['url'], bureau_code)
+    assert bureau_info["title"] == "Federal National Mortgage Association"
+    assert bureau_info["code"] == bureau_code
+    assert bureau_info["logo"] is None
+    assert_url(bureau_info["url"], bureau_code)
 
 
 def test_get_bureau_info_list():
     """Given a list of bureau codes, the first code is assumed."""
-    bureau_code = '010:04'
-    bureau_info = helpers.get_bureau_info([bureau_code, '418:00'])
+    bureau_code = "010:04"
+    bureau_info = helpers.get_bureau_info([bureau_code, "418:00"])
 
-    assert bureau_info['title'] == 'Bureau of Land Management'
-    assert bureau_info['code'] == bureau_code
-    assert bureau_info['logo'] == '/images/logos/010-04.png'
-    assert_url(bureau_info['url'], bureau_code)
+    assert bureau_info["title"] == "Bureau of Land Management"
+    assert bureau_info["code"] == bureau_code
+    assert bureau_info["logo"] == "/images/logos/010-04.png"
+    assert_url(bureau_info["url"], bureau_code)
 
 
 def test_get_bureau_info_invalid():
     """Assert None is returned and a warning is logged."""
-    helpers_logger = logging.getLogger('ckanext.datagovtheme.helpers')
-    with mock.patch.object(helpers_logger, 'warning') as mock_log_warning:
-        bureau_info = helpers.get_bureau_info('01004')
+    helpers_logger = logging.getLogger("ckanext.datagovtheme.helpers")
+    with mock.patch.object(helpers_logger, "warning") as mock_log_warning:
+        bureau_info = helpers.get_bureau_info("01004")
 
         assert bureau_info is None
-        mock_log_warning.assert_called_once_with('bureau code is invalid code=01004')
+        mock_log_warning.assert_called_once_with("bureau code is invalid code=01004")
 
 
 def test_get_bureau_info_none():

--- a/ckanext/datagovtheme/tests/test_notes.py
+++ b/ckanext/datagovtheme/tests/test_notes.py
@@ -1,25 +1,32 @@
 # encoding: utf-8
 import time
-import pytest
 
+import pytest
 from ckantoolkit.tests import factories
 
 
 # The /dataset page uses get_pkg_dict_extra which depends on HarvestObject,
 # hence the harvest extension. Include it for these tests.
-@pytest.mark.ckan_config('ckan.plugins', 'harvest geodatagov datagovtheme spatial_metadata')
-@pytest.mark.use_fixtures('with_plugins', 'clean_db', 'clean_index')
+@pytest.mark.ckan_config(
+    "ckan.plugins", "harvest geodatagov datagovtheme spatial_metadata"
+)
+@pytest.mark.use_fixtures("with_plugins", "clean_db", "clean_index")
 class TestNotes(object):
-    '''Tests for the ckanext.datagovtheme.plugin module.'''
+    """Tests for the ckanext.datagovtheme.plugin module."""
 
     def test_datagovtheme_html_loads(self, app):
 
-        notes = 'Notes for a test dataset'
-        name = 'random_test' + str(int(time.time()))
-        organization = factories.Organization(name='myorg2')
-        dataset = factories.Dataset(notes=notes, name=name, owner_org=organization['id'])
+        notes = "Notes for a test dataset"
+        name = "random_test" + str(int(time.time()))
+        organization = factories.Organization(name="myorg2")
+        dataset = factories.Dataset(
+            notes=notes, name=name, owner_org=organization["id"]
+        )
 
-        dataset_response = app.get('/dataset/{}'.format(dataset['name']))
+        dataset_response = app.get("/dataset/{}".format(dataset["name"]))
 
-        assert '<div itemprop="description" class="notes embedded-content">' in dataset_response.body
+        assert (
+            '<div itemprop="description" class="notes embedded-content">'
+            in dataset_response.body
+        )
         assert notes in dataset_response.body

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -4,3 +4,5 @@ flake8
 mock
 pytest
 pytest-cov
+black
+isort

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.3.5",
+    version="0.3.9",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
Related: Enhancement

Changes:
- Similar to [GSA/datagov-harvester](https://github.com/GSA/datagov-harvester) we should have similar formatting standards. This adds `black` and `isort` to the `dev-requirements.txt`.
- This PR also runs black and isort on the `ckanext` directory 

Note: 
This currently is only failing because we don't ignore W503 in the linting process. If [this PR ](https://github.com/GSA/data.gov/pull/5267) is approved and merged into the test-211 branch it should get this to pass.