### PR TITLE
ping ckanext-spatial to v2.3.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 
 # ckanext-harvest
 -e git+https://github.com/ckan/ckanext-harvest.git#egg=ckanext_harvest
--e git+https://github.com/ckan/ckanext-spatial.git#egg=ckanext-spatial
+-e git+https://github.com/ckan/ckanext-spatial.git@v2.3.0#egg=ckanext-spatial
 ckanext-geodatagov
 
 # ckanext-harvest dependencies


### PR DESCRIPTION
ckanext-spatial main and v2.3.1 (release 2025-06-11) breaks the test.
pin it to v2.3.0.