### PR TITLE
Change relevance secondary sorting

### DIFF
--- a/ckanext/datagovtheme/templates/snippets/sort_by.html
+++ b/ckanext/datagovtheme/templates/snippets/sort_by.html
@@ -11,7 +11,7 @@ Example:
 <div class="form-group control-order-by">
   <label for="field-order-by">{{ _('Order by') }}</label>
   <select id="field-order-by" name="sort" class="form-control form-select">
-    <option value="score desc, name asc"{% if sort =='score desc, name asc' %} selected="selected"{% endif %}>{{ _('Relevance') }}</option>
+    <option value="score desc, views_recent desc"{% if sort =='score desc, views_recent desc' %} selected="selected"{% endif %}>{{ _('Relevance') }}</option>
     <option value="title_string asc"{% if sort=='title_string asc' %} selected="selected"{% endif %}>{{ _('Name Ascending') }}</option>
     <option value="title_string desc"{% if sort=='title_string desc' %} selected="selected"{% endif %}>{{ _('Name Descending') }}</option>
     <option value="metadata_modified desc"{% if sort=='metadata_modified desc' %} selected="selected"{% endif %}>{{ _('Last Modified') }}</option>

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open(path.join(here, "README.md"), encoding="utf-8") as f:
 
 setup(
     name="ckanext-datagovtheme",
-    version="0.3.5",
+    version="0.4.0",
     description="CKAN Extension to manage data.gov theme",
     long_description=long_description,
     classifiers=[


### PR DESCRIPTION
Matches https://github.com/GSA/ckanext-geodatagov/pull/294, what should be the default.

Bumps version to 0.4.0. Will make 2 PR's to catalog, one to pin main on < 0.4.0, and the catalog-next/beta to use latest version.

No real tests on this PR, tests are on the other PR (where the behavior actually changes, not just a value).

Also related to https://github.com/GSA/data.gov/issues/5277