### PR TITLE
render landingPage URL as clickable link

### DIFF
--- a/ckanext/datagovtheme/templates/package/read.html
+++ b/ckanext/datagovtheme/templates/package/read.html
@@ -393,7 +393,11 @@
                 {% endif %}
 
                 {% if value != '[]' %}
-                     {{ value }}
+                  {% if h.is_url(value) %}
+                    <a href="{{ value }}" target="_blank" rel="nofollow">{{ value }}</a>
+                  {% else %}
+                    {{ value }}
+                  {% endif %}
                 {% endif %}
               </td>
             </tr>


### PR DESCRIPTION
For:
- https://github.com/GSA/data.gov/issues/5860

Changes:
- render landingPage URL as a clickable link in the additional metadata table