### PR TITLE
Add explicit workflow token permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,9 @@ on:
         description: 'Release Version:'
         required: true
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     name: Publish to PyPI

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@
 name: Tests
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   lint-test:
     name: Lint + Test


### PR DESCRIPTION
## Summary
- Add explicit `permissions` blocks to:
  - `.github/workflows/deploy.yml`
  - `.github/workflows/test.yml`
- Set `contents: read` as the minimal required scope for both workflows.

## Why
These workflows currently rely on implicit token defaults. Explicit scopes improve security posture and make token usage intent clear.