### PR TITLE
Fix documentation spelling errors from codespell

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ CKAN version | Compatibility
 
 ### Configuration
 
-_TODO: what configuraiton options exist?_
+_TODO: what configuration options exist?_
 
 
 ## Development


### PR DESCRIPTION
## Summary
- Fix high-confidence spelling typo in `README.md`.
- Keep change scoped to documentation only.

## Validation
- `codespell README.md`